### PR TITLE
[ANDROID-15] 앱모듈에서 컴포즈 의존성을 사용해서 생기는 오류

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,5 @@
 plugins {
     id("youth.android.application")
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.compose)
 }
 
 android {
@@ -15,10 +13,6 @@ android {
         versionCode = 1
         versionName = "1.0"
 
-    }
-
-    buildFeatures {
-        compose = true
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jul 14 15:38:27 KST 2025
+    #Mon Jul 14 15:38:27 KST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
🔗 관련 이슈

📙 작업 설명
앱 모듈에서 더이상 컴포즈를 사용하지 않는데
컴포즈 설정을 해주었고 컴포즈 버전을 명시해주지 않아서 생기는 문제 수정

🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)
