### PR TITLE
[ANDROID-19] 로그인 관련 Retrofit 객체 생성

### DIFF
--- a/build-logic/src/main/java/com/youth/app/KotlinAndroid.kt
+++ b/build-logic/src/main/java/com/youth/app/KotlinAndroid.kt
@@ -28,6 +28,7 @@ internal fun Project.configureKotlinAndroid() {
 
             testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
+            buildConfigField("String","SERVER_API_KEY", getApiKey("server.api.key"))
             buildConfigField("String", "KAKAO_API_KEY", getApiKey("kakao.api.key"))
             addManifestPlaceholders(mapOf("KAKAO_API_KEY" to getApiKey("kakao.api.xml.key")))
         }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    namespace = "record.daily.data"
+    namespace = "see.day.data"
 }
 
 dependencies {

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -1,5 +1,7 @@
 plugins {
     id("youth.android.library")
+    id("kotlinx-serialization")
+    kotlin("plugin.serialization")
 }
 
 android {
@@ -8,4 +10,12 @@ android {
 
 dependencies {
     implementation(project(":core:domain"))
+
+    implementation(libs.retrofit)
+    implementation(libs.okhttp)
+    implementation(platform(libs.okhttp.bom))
+    implementation(libs.okhttp3.okhttp)
+    implementation(libs.logging.interceptor)
+    implementation(libs.retrofit.kotlin.serialization)
+    implementation(libs.kotlinx.serialization.json)
 }

--- a/core/data/src/androidTest/java/see/day/data/ExampleInstrumentedTest.kt
+++ b/core/data/src/androidTest/java/see/day/data/ExampleInstrumentedTest.kt
@@ -1,4 +1,4 @@
-package record.daily.data
+package see.day.data
 
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -19,6 +19,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("record.daily.data.test", appContext.packageName)
+        assertEquals("see.day.data.test", appContext.packageName)
     }
 }

--- a/core/data/src/main/java/see/day/di/ApiModule.kt
+++ b/core/data/src/main/java/see/day/di/ApiModule.kt
@@ -1,0 +1,64 @@
+package see.day.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Qualifier
+import javax.inject.Singleton
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Converter.Factory
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import see.day.data.BuildConfig
+
+@Module
+@InstallIn(SingletonComponent::class)
+class ApiModule {
+
+    @Qualifier
+    @Retention(AnnotationRetention.RUNTIME)
+    annotation class Login
+
+    @Provides
+    @Singleton
+    fun provideJson(): Json = Json {
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+    }
+
+    @Provides
+    @Singleton
+    fun provideConverterFactory(json: Json): Factory {
+        return json.asConverterFactory("application/json".toMediaType())
+    }
+
+    @Provides
+    @Singleton
+    @Login
+    fun provideLoginOkHttp(): OkHttpClient {
+        val httpLoggingInterceptor = HttpLoggingInterceptor()
+        httpLoggingInterceptor.level = HttpLoggingInterceptor.Level.BODY
+
+        return OkHttpClient.Builder()
+            .addInterceptor(httpLoggingInterceptor)
+            .build()
+    }
+
+    @Singleton
+    @Provides
+    @Login
+    fun provideLoginRetrofit(
+        @Login okHttpClient: OkHttpClient,
+        converterFactory: Factory
+    ): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(BuildConfig.SERVER_API_KEY)
+            .addConverterFactory(converterFactory)
+            .client(okHttpClient)
+            .build()
+    }
+}

--- a/core/data/src/test/java/see/day/data/ExampleUnitTest.kt
+++ b/core/data/src/test/java/see/day/data/ExampleUnitTest.kt
@@ -1,4 +1,4 @@
-package record.daily.data
+package see.day.data
 
 import org.junit.Test
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,8 +27,6 @@ timberVersion = "5.0.1"
 
 ksp = "2.0.0-1.0.22"
 
-kotlinxSerializationJson = "1.8.0"
-
 navigationCompose = "2.8.1"
 jetbrainsKotlinJvm = "1.9.24"
 appcompat = "1.7.1"
@@ -39,6 +37,10 @@ kakaoUser = "2.20.1"
 googleServices = "4.4.3"
 
 ktlint = "12.1.1"
+
+okhttp = "4.12.0"
+retrofit = "2.11.0"
+kotlinxSerializationJson = "1.8.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -92,6 +94,15 @@ coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-
 
 #timber
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timberVersion" }
+
+#http
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor" }
+okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp" }
+okhttp3-okhttp = { module = "com.squareup.okhttp3:okhttp" }
+retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+retrofit-kotlin-serialization = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
+okhttp3-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp"}
 
 #Serialization
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }


### PR DESCRIPTION
🔗 관련 이슈

📙 작업 설명
로그인 관련 작업(토큰이 필요없거나 토큰을 요청하는 작업)에 필요한 Retrofit 객체를 생성했다.

core:data 모듈의 패키지명을 변경했다 (see.day.data)

🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)
