### PR TITLE
[ANDROID-21] 에러 핸들링 로직 작성

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -10,6 +10,7 @@ android {
 
 dependencies {
     implementation(project(":core:domain"))
+    implementation(project(":core:model"))
 
     implementation(libs.retrofit)
     implementation(libs.okhttp)

--- a/core/data/src/main/java/see/day/utils/ErrorUtils.kt
+++ b/core/data/src/main/java/see/day/utils/ErrorUtils.kt
@@ -32,7 +32,7 @@ object ErrorUtils {
             401 -> UnAuthorizedException(response.message)
             404 -> NotFoundException(response.message)
             400 -> BadRequestException(response.message)
-            500 -> InvalidValueException(response.message)
+            500 -> NetworkErrorException(response.message)
             else -> IllegalStateException(response.message)
         }
     }

--- a/core/data/src/main/java/see/day/utils/ErrorUtils.kt
+++ b/core/data/src/main/java/see/day/utils/ErrorUtils.kt
@@ -1,0 +1,39 @@
+package see.day.utils
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import record.daily.model.exception.BadRequestException
+import record.daily.model.exception.InvalidValueException
+import record.daily.model.exception.NetworkErrorException
+import record.daily.model.exception.NotFoundException
+import record.daily.model.exception.UnAuthorizedException
+import retrofit2.HttpException
+import see.day.network.dto.CommonResponse
+import timber.log.Timber
+
+object ErrorUtils {
+
+    inline fun <reified T, R> T.createResult(call: T.() -> R): Result<R> {
+        return try {
+            Result.success(call())
+        } catch (e: HttpException) {
+            Timber.e(e.message)
+            Result.failure(mapToCustomException<T>(e))
+        } catch (e: Exception) {
+            Timber.e(e.message)
+            Result.failure(NetworkErrorException(e.message))
+        }
+    }
+
+    inline fun <reified T> mapToCustomException(it: HttpException): Exception {
+        val error = it.response()?.errorBody()?.string() ?: throw InvalidValueException(it.message)
+        val response = Json.decodeFromString<CommonResponse<JsonElement?>>(error)
+        return when (it.code()) {
+            401 -> UnAuthorizedException(response.message)
+            404 -> NotFoundException(response.message)
+            400 -> BadRequestException(response.message)
+            500 -> InvalidValueException(response.message)
+            else -> IllegalStateException(response.message)
+        }
+    }
+}

--- a/core/data/src/test/java/see/day/data/api/error/ErrorTest.kt
+++ b/core/data/src/test/java/see/day/data/api/error/ErrorTest.kt
@@ -1,0 +1,79 @@
+package see.day.data.api.error
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import record.daily.model.exception.NetworkErrorException
+import see.day.data.api.ApiTestUtils
+import see.day.data.api.ApiTestUtils.createRetrofit
+import see.day.data.api.error.json.errorResponse
+import see.day.data.api.loginService.json.createLoginResponse
+import see.day.network.LoginService
+import see.day.network.dto.login.LoginRequest
+import see.day.utils.ErrorUtils.createResult
+
+class ErrorTest {
+
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var sut: LoginService
+    private lateinit var okHttpClient: OkHttpClient
+
+    @Before
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+
+        okHttpClient = OkHttpClient.Builder()
+            .addInterceptor(ApiTestUtils.httpLoggingInterceptor)
+            .build()
+
+        val retrofit = createRetrofit(
+            baseUrl = mockWebServer.url("/"),
+            client = okHttpClient
+        )
+
+        sut = retrofit.create(LoginService::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun givenLoginRequest_whenNetworkError_thenThrows500Exception() = runTest {
+        // given
+        val socialType = "kakao"
+        val accessToken = "Asdadejwlk23k4j1"
+
+        val loginRequest = LoginRequest(socialType, accessToken)
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(500)
+                .setBody(errorResponse)
+        )
+
+        // when
+        Assert.assertThrows(NetworkErrorException::class.java) {
+            runBlocking {
+                createResult {
+                    sut.signIn(loginRequest.toRequestBody())
+                }.onFailure {
+                    assertEquals("서버 내부 오류가 발생했습니다.",it.message)
+                }.getOrThrow()
+            }
+        }
+        Unit
+    }
+
+}

--- a/core/data/src/test/java/see/day/data/api/error/json/ErrorJson.kt
+++ b/core/data/src/test/java/see/day/data/api/error/json/ErrorJson.kt
@@ -1,0 +1,10 @@
+package see.day.data.api.error.json
+
+internal val errorResponse = """
+    {
+      "statusCode": 500,
+      "code": "ES0001",
+      "message": "서버 내부 오류가 발생했습니다.",
+      "data": null
+    }
+""".trimIndent()

--- a/core/model/src/main/java/record/daily/model/exception/BadRequestException.kt
+++ b/core/model/src/main/java/record/daily/model/exception/BadRequestException.kt
@@ -1,0 +1,3 @@
+package record.daily.model.exception
+
+data class BadRequestException(override val message: String?) : RuntimeException()

--- a/core/model/src/main/java/record/daily/model/exception/InvalidValueException.kt
+++ b/core/model/src/main/java/record/daily/model/exception/InvalidValueException.kt
@@ -1,0 +1,3 @@
+package record.daily.model.exception
+
+data class InvalidValueException(override val message: String? = "InvalidValueException") : RuntimeException()

--- a/core/model/src/main/java/record/daily/model/exception/NetworkErrorException.kt
+++ b/core/model/src/main/java/record/daily/model/exception/NetworkErrorException.kt
@@ -1,0 +1,3 @@
+package record.daily.model.exception
+
+data class NetworkErrorException(override val message: String? = "NetworkErrorException") : RuntimeException()

--- a/core/model/src/main/java/record/daily/model/exception/NotFoundException.kt
+++ b/core/model/src/main/java/record/daily/model/exception/NotFoundException.kt
@@ -1,0 +1,3 @@
+package record.daily.model.exception
+
+data class NotFoundException(override val message: String?) : RuntimeException()

--- a/core/model/src/main/java/record/daily/model/exception/UnAuthorizedException.kt
+++ b/core/model/src/main/java/record/daily/model/exception/UnAuthorizedException.kt
@@ -1,0 +1,3 @@
+package record.daily.model.exception
+
+data class UnAuthorizedException(override val message: String?) : RuntimeException()


### PR DESCRIPTION
🔗 관련 이슈

📙 작업 설명
domain, presentation 레이어는 HTTPException에 대한 의존성이 없으므로
직접 커스텀 익셉션을 작성했다.

api 결과값을 특정 Exception으로 변환하는 코드를 작성하였다
🧪 테스트 내역 (선택)
테스트 결과 정상적으로 500Exception을 커스텀 익셉션으로 전환하였다.
📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)
