### PR TITLE
[ANDROID-29] 로그인 API 변경에 따른 Repository 코드 변경

### DIFF
--- a/core/data/src/main/java/see/day/datastore/DataStoreDataSource.kt
+++ b/core/data/src/main/java/see/day/datastore/DataStoreDataSource.kt
@@ -8,7 +8,9 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import see.day.datastore.DataStoreDataSource.PreferencesKey.ACCESS_TOKEN
+import see.day.datastore.DataStoreDataSource.PreferencesKey.APP_START_STATE
 import see.day.datastore.DataStoreDataSource.PreferencesKey.REFRESH_TOKEN
+import see.day.model.navigation.AppStartState
 
 class DataStoreDataSource @Inject constructor(
     private val dataStore: DataStore<Preferences>
@@ -16,7 +18,7 @@ class DataStoreDataSource @Inject constructor(
     object PreferencesKey {
         val ACCESS_TOKEN = stringPreferencesKey("ACCESS_TOKEN")
         val REFRESH_TOKEN = stringPreferencesKey("REFRESH_TOKEN")
-        val NAV_APP_STATE = stringPreferencesKey("APP_NAV_STATE")
+        val APP_START_STATE = stringPreferencesKey("APP_NAV_STATE")
     }
 
     override fun hasToken(): Flow<Boolean> = dataStore.data.map { preferences ->
@@ -35,6 +37,12 @@ class DataStoreDataSource @Inject constructor(
         }
     }
 
+    fun getAppStartState(): Flow<AppStartState> {
+        return dataStore.data.map { prefs ->
+            AppStartState.fromString(prefs[APP_START_STATE])
+        }
+    }
+
     suspend fun saveAccessToken(token: String) {
         dataStore.edit { prefs ->
             prefs[ACCESS_TOKEN] = token
@@ -44,6 +52,12 @@ class DataStoreDataSource @Inject constructor(
     suspend fun saveRefreshToken(token: String) {
         dataStore.edit { prefs ->
             prefs[REFRESH_TOKEN] = token
+        }
+    }
+
+    suspend fun saveAppStartState(state: AppStartState) {
+        dataStore.edit { prefs ->
+            prefs[APP_START_STATE] = state.toString().uppercase()
         }
     }
 

--- a/core/data/src/main/java/see/day/datastore/DataStoreDataSource.kt
+++ b/core/data/src/main/java/see/day/datastore/DataStoreDataSource.kt
@@ -16,6 +16,7 @@ class DataStoreDataSource @Inject constructor(
     object PreferencesKey {
         val ACCESS_TOKEN = stringPreferencesKey("ACCESS_TOKEN")
         val REFRESH_TOKEN = stringPreferencesKey("REFRESH_TOKEN")
+        val NAV_APP_STATE = stringPreferencesKey("APP_NAV_STATE")
     }
 
     override fun hasToken(): Flow<Boolean> = dataStore.data.map { preferences ->

--- a/core/data/src/main/java/see/day/mapper/LoginMapper.kt
+++ b/core/data/src/main/java/see/day/mapper/LoginMapper.kt
@@ -1,6 +1,6 @@
 package see.day.mapper
 
-import record.daily.model.login.SocialLogin
+import see.day.model.login.SocialLogin
 import see.day.network.dto.login.LoginRequest
 
 fun SocialLogin.toDto(): LoginRequest {

--- a/core/data/src/main/java/see/day/network/dto/common/UserDto.kt
+++ b/core/data/src/main/java/see/day/network/dto/common/UserDto.kt
@@ -6,5 +6,8 @@ import kotlinx.serialization.Serializable
 data class UserDto(
     val id: String?,
     val name: String?,
-    val email: String?
+    val email: String?,
+    val socialType: String,
+    val createdAt: String,
+    val onboardingCompleted: Boolean
 )

--- a/core/data/src/main/java/see/day/network/dto/login/LoginResponse.kt
+++ b/core/data/src/main/java/see/day/network/dto/login/LoginResponse.kt
@@ -10,4 +10,8 @@ data class LoginResponse(
     val refreshToken: String,
     val user: UserDto,
     @SerialName("newUser") val isNewUser: Boolean
-)
+) {
+    fun isOnboardingComplete(): Boolean {
+        return !isNewUser && user.onboardingCompleted
+    }
+}

--- a/core/data/src/main/java/see/day/repository/LoginRepositoryImpl.kt
+++ b/core/data/src/main/java/see/day/repository/LoginRepositoryImpl.kt
@@ -3,8 +3,8 @@ package see.day.repository
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import record.daily.model.exception.NoDataException
-import record.daily.model.login.SocialLogin
+import see.day.model.exception.NoDataException
+import see.day.model.login.SocialLogin
 import see.day.datastore.DataStoreDataSource
 import see.day.domain.repository.LoginRepository
 import see.day.mapper.toDto

--- a/core/data/src/main/java/see/day/utils/ErrorUtils.kt
+++ b/core/data/src/main/java/see/day/utils/ErrorUtils.kt
@@ -2,12 +2,12 @@ package see.day.utils
 
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import retrofit2.HttpException
 import see.day.model.exception.BadRequestException
 import see.day.model.exception.InvalidValueException
 import see.day.model.exception.NetworkErrorException
 import see.day.model.exception.NotFoundException
 import see.day.model.exception.UnAuthorizedException
-import retrofit2.HttpException
 import see.day.network.dto.CommonResponse
 import timber.log.Timber
 

--- a/core/data/src/main/java/see/day/utils/ErrorUtils.kt
+++ b/core/data/src/main/java/see/day/utils/ErrorUtils.kt
@@ -2,11 +2,11 @@ package see.day.utils
 
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
-import record.daily.model.exception.BadRequestException
-import record.daily.model.exception.InvalidValueException
-import record.daily.model.exception.NetworkErrorException
-import record.daily.model.exception.NotFoundException
-import record.daily.model.exception.UnAuthorizedException
+import see.day.model.exception.BadRequestException
+import see.day.model.exception.InvalidValueException
+import see.day.model.exception.NetworkErrorException
+import see.day.model.exception.NotFoundException
+import see.day.model.exception.UnAuthorizedException
 import retrofit2.HttpException
 import see.day.network.dto.CommonResponse
 import timber.log.Timber

--- a/core/data/src/test/java/see/day/data/api/error/ErrorTest.kt
+++ b/core/data/src/test/java/see/day/data/api/error/ErrorTest.kt
@@ -10,7 +10,7 @@ import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import record.daily.model.exception.NetworkErrorException
+import see.day.model.exception.NetworkErrorException
 import see.day.data.api.ApiTestUtils
 import see.day.data.api.ApiTestUtils.createRetrofit
 import see.day.data.api.error.json.errorResponse

--- a/core/data/src/test/java/see/day/data/api/loginService/LoginTest.kt
+++ b/core/data/src/test/java/see/day/data/api/loginService/LoginTest.kt
@@ -6,7 +6,6 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail

--- a/core/data/src/test/java/see/day/data/api/loginService/LoginTest.kt
+++ b/core/data/src/test/java/see/day/data/api/loginService/LoginTest.kt
@@ -9,6 +9,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 import see.day.data.api.ApiTestUtils
@@ -75,7 +76,9 @@ class LoginTest {
         assertEquals("요청이 성공적으로 처리되었습니다.", response.message)
         assertEquals("S200", response.code)
         assertNotNull(response.data)
-        assertTrue(response.data?.isNewUser ?: false)
+        response.data?.let { data ->
+            assertTrue(data.isNewUser || !data.user.onboardingCompleted)
+        } ?: fail()
     }
 
     @Test
@@ -107,6 +110,8 @@ class LoginTest {
         assertEquals("요청이 성공적으로 처리되었습니다.", response.message)
         assertEquals("S201", response.code)
         assertNotNull(response.data)
-        assertFalse(response.data?.isNewUser ?: true)
+        response.data?.let { data ->
+            assertTrue(!data.isNewUser && data.user.onboardingCompleted)
+        } ?: fail()
     }
 }

--- a/core/data/src/test/java/see/day/data/api/loginService/json/LoginJson.kt
+++ b/core/data/src/test/java/see/day/data/api/loginService/json/LoginJson.kt
@@ -9,7 +9,10 @@ internal val createLoginResponse = """
         "user": {
           "id": "user_123456",
           "name": "홍길동",
-          "email": "hong@example.com"
+          "email": "hong@example.com",
+          "socialType": "KAKAO",
+          "createdAt": "2025-09-02T02:46:41.454753",
+          "onboardingCompleted": false
         },
         "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
         "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
@@ -27,7 +30,10 @@ internal val oldLoginResponse = """
         "user": {
           "id": "user_123456",
           "name": "홍길동",
-          "email": "hong@example.com"
+          "email": "hong@example.com",
+          "socialType": "KAKAO",
+          "createdAt": "2025-09-02T02:46:41.454753",
+          "onboardingCompleted": true
         },
         "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
         "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",

--- a/core/data/src/test/java/see/day/data/mapper/LoginMapperTest.kt
+++ b/core/data/src/test/java/see/day/data/mapper/LoginMapperTest.kt
@@ -2,8 +2,8 @@ package see.day.data.mapper
 
 import org.junit.Assert
 import org.junit.Test
-import record.daily.model.login.SocialLogin
-import record.daily.model.login.SocialType
+import see.day.model.login.SocialLogin
+import see.day.model.login.SocialType
 import see.day.mapper.toDto
 
 class LoginMapperTest {

--- a/core/data/src/test/java/see/day/data/repository/LoginRepositoryTest.kt
+++ b/core/data/src/test/java/see/day/data/repository/LoginRepositoryTest.kt
@@ -14,9 +14,9 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import record.daily.model.exception.BadRequestException
-import record.daily.model.login.SocialLogin
-import record.daily.model.login.SocialType
+import see.day.model.exception.BadRequestException
+import see.day.model.login.SocialLogin
+import see.day.model.login.SocialType
 import retrofit2.HttpException
 import retrofit2.Response
 import see.day.datastore.DataStoreDataSource

--- a/core/data/src/test/java/see/day/data/repository/LoginRepositoryTest.kt
+++ b/core/data/src/test/java/see/day/data/repository/LoginRepositoryTest.kt
@@ -21,6 +21,9 @@ import retrofit2.HttpException
 import retrofit2.Response
 import see.day.datastore.DataStoreDataSource
 import see.day.domain.repository.LoginRepository
+import see.day.model.navigation.AppStartState
+import see.day.model.navigation.AppStartState.MAIN
+import see.day.model.navigation.AppStartState.ONBOARDING
 import see.day.network.LoginService
 import see.day.network.dto.CommonResponse
 import see.day.network.dto.common.UserDto
@@ -57,20 +60,22 @@ class LoginRepositoryTest {
                     200,
                     "S200",
                     "요청이 성공적으로 처리되었습니다.",
-                    LoginResponse(accessToken, refreshToken, UserDto("", "", "","","",false), isNewUser = true)
+                    LoginResponse(accessToken, refreshToken, UserDto("", "", "", "", "", false), isNewUser = true)
                 )
             )
             whenever(dataSource.saveAccessToken(accessToken)).thenReturn(Unit)
             whenever(dataSource.saveRefreshToken(refreshToken)).thenReturn(Unit)
+            whenever(dataSource.saveAppStartState(ONBOARDING)).thenReturn(Unit)
 
             // when
             val result = sut.login(newSocialLogin).getOrThrow()
 
             // then
-            assertTrue(result)
+            assertEquals(ONBOARDING, result)
 
             verify(dataSource).saveAccessToken(accessToken)
             verify(dataSource).saveRefreshToken(refreshToken)
+            verify(dataSource).saveAppStartState(ONBOARDING)
             verify(loginService).signIn(any())
         }
     }
@@ -88,20 +93,22 @@ class LoginRepositoryTest {
                     201,
                     "S201",
                     "요청이 성공적으로 처리되었습니다.",
-                    LoginResponse(accessToken, refreshToken, UserDto("", "", "","","",false), isNewUser = false)
+                    LoginResponse(accessToken, refreshToken, UserDto("", "", "", "", "", true), isNewUser = false)
                 )
             )
             whenever(dataSource.saveAccessToken(accessToken)).thenReturn(Unit)
             whenever(dataSource.saveRefreshToken(refreshToken)).thenReturn(Unit)
+            whenever(dataSource.saveAppStartState(MAIN)).thenReturn(Unit)
 
             // when
             val result = sut.login(oldSocialLogin).getOrThrow()
 
             // then
-            assertFalse(result)
+            assertEquals(MAIN, result)
 
             verify(dataSource).saveAccessToken(accessToken)
             verify(dataSource).saveRefreshToken(refreshToken)
+            verify(dataSource).saveAppStartState(MAIN)
             verify(loginService).signIn(any())
         }
     }

--- a/core/data/src/test/java/see/day/data/repository/LoginRepositoryTest.kt
+++ b/core/data/src/test/java/see/day/data/repository/LoginRepositoryTest.kt
@@ -57,7 +57,7 @@ class LoginRepositoryTest {
                     200,
                     "S200",
                     "요청이 성공적으로 처리되었습니다.",
-                    LoginResponse(accessToken, refreshToken, UserDto("", "", ""), isNewUser = true)
+                    LoginResponse(accessToken, refreshToken, UserDto("", "", "","","",false), isNewUser = true)
                 )
             )
             whenever(dataSource.saveAccessToken(accessToken)).thenReturn(Unit)
@@ -88,7 +88,7 @@ class LoginRepositoryTest {
                     201,
                     "S201",
                     "요청이 성공적으로 처리되었습니다.",
-                    LoginResponse(accessToken, refreshToken, UserDto("", "", ""), isNewUser = false)
+                    LoginResponse(accessToken, refreshToken, UserDto("", "", "","","",false), isNewUser = false)
                 )
             )
             whenever(dataSource.saveAccessToken(accessToken)).thenReturn(Unit)

--- a/core/domain/src/main/java/see/day/domain/repository/LoginRepository.kt
+++ b/core/domain/src/main/java/see/day/domain/repository/LoginRepository.kt
@@ -1,7 +1,8 @@
 package see.day.domain.repository
 
 import see.day.model.login.SocialLogin
+import see.day.model.navigation.AppStartState
 
 interface LoginRepository {
-    suspend fun login(socialLogin: SocialLogin) : Result<Boolean>
+    suspend fun login(socialLogin: SocialLogin) : Result<AppStartState>
 }

--- a/core/domain/src/main/java/see/day/domain/repository/LoginRepository.kt
+++ b/core/domain/src/main/java/see/day/domain/repository/LoginRepository.kt
@@ -1,6 +1,6 @@
 package see.day.domain.repository
 
-import record.daily.model.login.SocialLogin
+import see.day.model.login.SocialLogin
 
 interface LoginRepository {
     suspend fun login(socialLogin: SocialLogin) : Result<Boolean>

--- a/core/model/src/main/java/see/day/model/exception/BadRequestException.kt
+++ b/core/model/src/main/java/see/day/model/exception/BadRequestException.kt
@@ -1,3 +1,3 @@
-package record.daily.model.exception
+package see.day.model.exception
 
 data class BadRequestException(override val message: String?) : RuntimeException()

--- a/core/model/src/main/java/see/day/model/exception/InvalidValueException.kt
+++ b/core/model/src/main/java/see/day/model/exception/InvalidValueException.kt
@@ -1,3 +1,3 @@
-package record.daily.model.exception
+package see.day.model.exception
 
 data class InvalidValueException(override val message: String? = "InvalidValueException") : RuntimeException()

--- a/core/model/src/main/java/see/day/model/exception/NetworkErrorException.kt
+++ b/core/model/src/main/java/see/day/model/exception/NetworkErrorException.kt
@@ -1,3 +1,3 @@
-package record.daily.model.exception
+package see.day.model.exception
 
 data class NetworkErrorException(override val message: String? = "NetworkErrorException") : RuntimeException()

--- a/core/model/src/main/java/see/day/model/exception/NoDataException.kt
+++ b/core/model/src/main/java/see/day/model/exception/NoDataException.kt
@@ -1,3 +1,3 @@
-package record.daily.model.exception
+package see.day.model.exception
 
 data class NoDataException(override val message: String? = "데이터가 존재하지 않습니다.") : RuntimeException()

--- a/core/model/src/main/java/see/day/model/exception/NotFoundException.kt
+++ b/core/model/src/main/java/see/day/model/exception/NotFoundException.kt
@@ -1,3 +1,3 @@
-package record.daily.model.exception
+package see.day.model.exception
 
 data class NotFoundException(override val message: String?) : RuntimeException()

--- a/core/model/src/main/java/see/day/model/exception/UnAuthorizedException.kt
+++ b/core/model/src/main/java/see/day/model/exception/UnAuthorizedException.kt
@@ -1,3 +1,3 @@
-package record.daily.model.exception
+package see.day.model.exception
 
 data class UnAuthorizedException(override val message: String?) : RuntimeException()

--- a/core/model/src/main/java/see/day/model/login/SocialLogin.kt
+++ b/core/model/src/main/java/see/day/model/login/SocialLogin.kt
@@ -1,4 +1,4 @@
-package record.daily.model.login
+package see.day.model.login
 
 data class SocialLogin(
     val socialType: SocialType,

--- a/core/model/src/main/java/see/day/model/login/SocialType.kt
+++ b/core/model/src/main/java/see/day/model/login/SocialType.kt
@@ -1,4 +1,4 @@
-package record.daily.model.login
+package see.day.model.login
 
 enum class SocialType(name: String) {
     KAKAO("kakao")

--- a/core/model/src/main/java/see/day/model/navigation/AppStartState.kt
+++ b/core/model/src/main/java/see/day/model/navigation/AppStartState.kt
@@ -1,0 +1,20 @@
+package see.day.model.navigation
+
+enum class AppStartState {
+    LOGIN,
+    ONBOARDING,
+    MAIN;
+
+    companion object {
+        fun fromString(value: String?): AppStartState {
+            if (value == null) {
+                return LOGIN
+            }
+            return try {
+                valueOf(value.uppercase())
+            } catch (e: IllegalArgumentException) {
+                LOGIN
+            }
+        }
+    }
+}

--- a/core/model/src/main/java/see/day/model/user/User.kt
+++ b/core/model/src/main/java/see/day/model/user/User.kt
@@ -1,4 +1,4 @@
-package record.daily.model.user
+package see.day.model.user
 
 data class User(
     val id: String,


### PR DESCRIPTION
🔗 관련 이슈

📙 작업 설명
DataStore에 앱 실행시 이동 위치를 저장시켜놨다.
REFRESH_TOKEN을 보유하고 있더라도 온보딩으로 이동할수도 있고 메인으로 이동할수 있기때문에 이동 위치를 저장했다.


🧪 테스트 내역 (선택)
로그인 응답 결과에 따른 앱 위치 변경 상태가 잘 내려오는지 테스트
📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)
