### PR TITLE
[ANDROID-45] 앱 시작점이 설정되고 홈 화면이나 온보딩 화면으로는 다시 이동하지 않도록 설정

### DIFF
--- a/feature/main/src/main/java/see/day/main/MainActivity.kt
+++ b/feature/main/src/main/java/see/day/main/MainActivity.kt
@@ -44,13 +44,19 @@ class MainActivity : ComponentActivity() {
                     appStartDestination = when (appStartState) {
                         AppStartState.LOGIN -> LOGIN_ROUTE
                         AppStartState.HOME -> {
-                            if (appStartDestination != ONBOARDING_ROUTE) {
+                            if(appStartDestination == null) {
                                 HOME_ROUTE
                             } else {
                                 appStartDestination
                             }
                         }
-                        AppStartState.ONBOARDING -> ONBOARDING_ROUTE
+                        AppStartState.ONBOARDING -> {
+                            if(appStartDestination == null) {
+                                ONBOARDING_ROUTE
+                            } else {
+                                appStartDestination
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
로그인의 경우 리프레시토큰이 만료되었을때 이동하는데
이 제어를 모든 화면에서 다 할수가 없기 때문에
로그인 경로 이동만 남겨두고
온보딩 화면이나 홈 화면은 한번만 이동하도록 설정

🔗 관련 이슈

📙 작업 설명

🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)
