### PR TITLE
[ANDROID-63] 필터간 변환할 때 정상적으로 아이콘이 나오지 않던 문제 수정

### DIFF
--- a/feature/home/src/main/java/see/day/home/viewModel/HomeViewModel.kt
+++ b/feature/home/src/main/java/see/day/home/viewModel/HomeViewModel.kt
@@ -122,7 +122,7 @@ class HomeViewModel @Inject constructor(
         _uiState.update {
             it.copy(
                 selectedFilterType = filterType,
-                monthlyRecords = it.monthlyRecords.filterMonthlyRecords(filterType.toRecordType() ?: throw IllegalStateException())
+                monthlyRecords = monthlyRecord.value.filterMonthlyRecords(filterType.toRecordType() ?: throw IllegalStateException())
             )
         }
     }
@@ -161,8 +161,8 @@ class HomeViewModel @Inject constructor(
                 it.year,
                 it.month,
                 it.day,
-                it.records.filter {
-                    it == recordType
+                it.records.filter { record ->
+                    record == recordType
                 },
                 it.schedules
             )


### PR DESCRIPTION
🔗 관련 이슈

📙 작업 설명
전체 -> 운동으로 바꿀때는 괜찮은데
운동 -> 일상으로 변경할 때 문제가 발생했다.

필터를 변경할 때 이번달의 데이터에서 필터링하던게 현재 UiState의 데이터라서 정상적으로 출력이 되지 않았던것이다.
🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)
