### PR TITLE
[ANDROID-90] 필터링 할 때 카드 UI도 필터링 되도록 설정

### DIFF
--- a/feature/home/src/main/java/see/day/home/screen/HomeScreenRoot.kt
+++ b/feature/home/src/main/java/see/day/home/screen/HomeScreenRoot.kt
@@ -293,9 +293,19 @@ private fun HomeBottomSheetContent(
                 .height(1.dp)
                 .background(gray30)
         )
-        if (uiState.dailyRecordDetails.records.isNotEmpty()) {
+
+        val filteredRecords = remember(
+            uiState.selectedFilterType,
+            uiState.dailyRecordDetails.records
+        ) {
+            uiState.selectedFilterType.toRecordType()?.let { selectedType ->
+                uiState.dailyRecordDetails.records.filter { it.type == selectedType }
+            } ?: uiState.dailyRecordDetails.records
+        }
+
+        if (filteredRecords.isNotEmpty()) {
             CalendarDetail(
-                dailyRecordDetails = uiState.dailyRecordDetails,
+                dailyRecordDetails = uiState.dailyRecordDetails.copy(records = filteredRecords),
                 onClickOverview = { recordType, recordId ->
                     uiEvent(HomeUiEvent.OnClickDetailButton(recordType, recordId))
                 },


### PR DESCRIPTION
🔗 관련 이슈

📙 작업 설명
홈 화면의 캘린더 하단의 카드 UI도 필터 조건에 맞춰서
필터링 되도록 설정
🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)
