### PR TITLE
카드 UI가 나오는 하단이 좀 남도록 설정 (습관 완료 버튼 가림)

### DIFF
--- a/feature/home/src/main/java/see/day/home/screen/HomeScreenRoot.kt
+++ b/feature/home/src/main/java/see/day/home/screen/HomeScreenRoot.kt
@@ -330,6 +330,7 @@ private fun HomeBottomSheetContent(
                     uiEvent(HomeUiEvent.OnClickUpdateHabitIsComplete(recordId, isCompleted))
                 }
             )
+            Spacer(modifier = Modifier.height(100.dp))
             Spacer(modifier = modifier.systemBarsPadding())
         }
     }


### PR DESCRIPTION
🔗 관련 이슈

📙 작업 설명
만약 선택한 날짜에 기록이 있다면(홈 화면에 카드 UI가 존재한다면)
하단에 100dp 정도 여유를 남아서 습관 기록의 완료 버튼을 가리지 않도록 설정
🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)
