### PR TITLE
[ANDROID-142] 목표설정 텍스트가 중앙으로 오지 않는것 수정

### DIFF
--- a/feature/goal/src/main/java/see/day/goal/component/GoalRecordDateCard.kt
+++ b/feature/goal/src/main/java/see/day/goal/component/GoalRecordDateCard.kt
@@ -60,8 +60,10 @@ internal fun GoalRecordDateCard(
             .fillMaxHeight()
             .background(gray40))
 
+        Spacer(modifier = Modifier.weight(1f))
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.fillMaxWidth()
         ) {
             Text(
                 text = stringResource(R.string.goal_during),


### PR DESCRIPTION
🔗 관련 이슈

📙 작업 설명
텍스트가 중앙으로 오도록 수정
🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)
