### PR TITLE
[ANDROID-155] 사진 권한 삭제

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,13 +11,6 @@
         android:maxSdkVersion="32"
         tools:ignore="ScopedStorage" />
 
-
-
-    <uses-feature
-        android:name="android.hardware.camera"
-        android:required="false" />
-    <uses-permission android:name="android.permission.CAMERA" />
-
     <application
         android:name="record.daily.android.RecordApplication"
         android:allowBackup="true"


### PR DESCRIPTION
🔗 관련 이슈

📙 작업 설명
사진을 앱에서 직접 찍지 않기때문에 해당 권한을 삭제하였다
심사에서도 시비가 걸릴 수 있기때문에 사용하지 않는 권한은 미리미리 정리

🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기타 변경사항**
  * 앱에서 카메라 기능 및 카메라 접근 권한이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->