### PR TITLE
[ANDROID-159] 오늘이 아닌 날짜에서 습관 완료를 못하도록 수정

### DIFF
--- a/core/ui/src/main/java/see/day/ui/component/record/overview/HabitRecordOverview.kt
+++ b/core/ui/src/main/java/see/day/ui/component/record/overview/HabitRecordOverview.kt
@@ -48,7 +48,7 @@ fun HabitRecordOverView(
     habitRecord: HabitRecordDetail,
     onClickItem: (RecordType, String) -> Unit,
     onClickLongItem: () -> Unit,
-    onClickChecked: (String, Boolean) -> Unit
+    onClickChecked: (String, Boolean, String) -> Unit
 ) {
     Row(
         modifier = modifier
@@ -112,7 +112,7 @@ fun HabitRecordOverView(
         Box(
             modifier = Modifier
                 .size(44.dp)
-                .clickable { onClickChecked(habitRecord.id, !habitRecord.isCompleted) }
+                .clickable { onClickChecked(habitRecord.id, !habitRecord.isCompleted, habitRecord.recordDate) }
         ) {
             Image(
                 painter = painterResource(if (habitRecord.isCompleted) see.day.designsystem.R.drawable.ic_checked else see.day.designsystem.R.drawable.ic_unchecked),
@@ -137,7 +137,7 @@ private fun HabitRecordOverViewPreview() {
                 Toast.makeText(context, "onItemClick", Toast.LENGTH_SHORT).show()
             },
             onClickLongItem = {},
-            onClickChecked = { id, isChecked ->
+            onClickChecked = { id, isChecked, recordDate ->
                 habitRecord = habitRecord.copy(isCompleted = isChecked)
             }
         )
@@ -154,7 +154,7 @@ private fun HabitRecordOverViewIsMainPreview() {
             onClickItem = { type, id ->
             },
             onClickLongItem = {},
-            onClickChecked = { id, isChecked ->
+            onClickChecked = { id, isChecked, recordDate ->
             }
         )
     }

--- a/feature/home/src/main/java/see/day/home/component/CalendarDetail.kt
+++ b/feature/home/src/main/java/see/day/home/component/CalendarDetail.kt
@@ -42,7 +42,7 @@ fun CalendarDetail(
     dailyRecordDetails: DailyRecordDetails,
     onClickRevise: (RecordType, String) -> Unit,
     onClickDelete: (RecordType, String) -> Unit,
-    onClickUpdateHabitRecordIsCompleted: (String, Boolean) -> Unit
+    onClickUpdateHabitRecordIsCompleted: (String, Boolean, String) -> Unit
 ) {
     var openLongPressureDialog by remember { mutableStateOf(Triple(false, RecordType.DAILY, "")) }
     if (openLongPressureDialog.first) {
@@ -180,7 +180,7 @@ private fun CalendarDetailPreview() {
             ),
             onClickRevise = { recordType, recordId -> },
             onClickDelete = { recordType, recordId -> },
-            onClickUpdateHabitRecordIsCompleted = { recordId, isCompleted -> }
+            onClickUpdateHabitRecordIsCompleted = { recordId, isCompleted, recordDate -> }
         )
     }
 }

--- a/feature/home/src/main/java/see/day/home/screen/HomeScreenRoot.kt
+++ b/feature/home/src/main/java/see/day/home/screen/HomeScreenRoot.kt
@@ -379,8 +379,8 @@ private fun HomeBottomSheetContent(
                 onClickDelete = { recordType, recordId ->
                     uiEvent(HomeUiEvent.OnClickDeleteItem(recordType, recordId))
                 },
-                onClickUpdateHabitRecordIsCompleted = { recordId, isCompleted ->
-                    uiEvent(HomeUiEvent.OnClickUpdateHabitIsComplete(recordId, isCompleted))
+                onClickUpdateHabitRecordIsCompleted = { recordId, isCompleted, recordDate ->
+                    uiEvent(HomeUiEvent.OnClickUpdateHabitIsComplete(recordId, isCompleted, recordDate))
                 }
             )
             Spacer(modifier = Modifier.height(100.dp))

--- a/feature/home/src/main/java/see/day/home/state/HomeUiEvent.kt
+++ b/feature/home/src/main/java/see/day/home/state/HomeUiEvent.kt
@@ -12,7 +12,7 @@ sealed interface HomeUiEvent {
     data class OnClickDetailButton(val recordType: RecordType, val recordId: String) : HomeUiEvent
     data object OnClickSetting : HomeUiEvent
     data class OnClickDeleteItem(val recordType: RecordType, val recordId: String) : HomeUiEvent
-    data class OnClickUpdateHabitIsComplete(val recordId: String, val isCompleted: Boolean) : HomeUiEvent
+    data class OnClickUpdateHabitIsComplete(val recordId: String, val isCompleted: Boolean, val recordDate: String) : HomeUiEvent
     data object OnClickNotification : HomeUiEvent
     data object OnClickGoalSetting: HomeUiEvent
 }

--- a/feature/home/src/main/java/see/day/home/viewModel/HomeViewModel.kt
+++ b/feature/home/src/main/java/see/day/home/viewModel/HomeViewModel.kt
@@ -148,7 +148,7 @@ class HomeViewModel @Inject constructor(
             }
 
             is HomeUiEvent.OnClickUpdateHabitIsComplete -> {
-                onClickHabitRecordIsCompleted(recordId = uiEvent.recordId, isCompleted = uiEvent.isCompleted)
+                onClickHabitRecordIsCompleted(recordId = uiEvent.recordId, isCompleted = uiEvent.isCompleted, recordDate = uiEvent.recordDate)
             }
             is HomeUiEvent.OnClickNotification -> {
                 onClickNotification()
@@ -325,7 +325,10 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private fun onClickHabitRecordIsCompleted(recordId: String, isCompleted: Boolean) {
+    private fun onClickHabitRecordIsCompleted(recordId: String, isCompleted: Boolean, recordDate: String) {
+        if(recordDate != HomeUiState.getTodayDate()) {
+            return
+        }
         viewModelScope.launch {
             updateHabitRecordIsCompletedUseCase(recordId, isCompleted)
                 .onSuccess {


### PR DESCRIPTION
🔗 관련 이슈

📙 작업 설명
오늘이 아닌 날짜에서 습관 완료를 못하도록 변경하였다.
ui단에서 처리하려했지만
현재 습관 카드는 현재 날짜를 조회하기 어려워서 이렇게 작성하였다.
🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 습관 기록 토글 시 기록 날짜 정보가 함께 전달되도록 수정되었습니다. 오늘 날짜의 기록만 업데이트 가능하며, 과거 기록 수정은 처리되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->