### PR TITLE
[ANDROID-161] accessToken이 유효하지 않을 때 동시에 API 요청이 갔을때 안전하게 토큰 받도록 수정

### DIFF
--- a/core/data/src/main/java/see/day/di/TokenAuthenticator.kt
+++ b/core/data/src/main/java/see/day/di/TokenAuthenticator.kt
@@ -4,6 +4,8 @@ import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import okhttp3.Authenticator
 import okhttp3.Request
@@ -19,33 +21,51 @@ class TokenAuthenticator @Inject constructor(
     @Auth private val authService: AuthService
 ) : Authenticator {
 
+    private val mutex = Mutex()
+
     override fun authenticate(route: Route?, response: Response): Request? {
         if (responseCount(response) >= 2) {
             return null
         }
 
         return runBlocking {
-            runCatching {
-                val refreshToken = dataStore.getRefreshToken().first() ?: throw IllegalStateException("Refresh token is null")
-                val tokenResponse = authService.refresh(RefreshTokenRequest(refreshToken))
+            mutex.withLock {
+                // 이미 다른 요청이 토큰을 갱신했는지 확인
+                val currentToken = dataStore.getAccessToken().first()
+                val requestToken = response.request.header("Authorization")?.removePrefix("Bearer ")
 
-                if (tokenResponse.statusCode != 200 && tokenResponse.data == null) {
-                    throw IllegalStateException("refreshToken 발급 실패")
-                }
-                val tokenData = tokenResponse.data?.accessToken ?: throw IllegalStateException("token is null")
-                val newRefreshToken = tokenResponse.data.refreshToken
-
-                withContext(Dispatchers.IO) {
-                    dataStore.saveAccessToken(tokenData)
-                    dataStore.saveRefreshToken(newRefreshToken)
+                // 토큰이 이미 갱신되었다면 새 토큰으로 재시도
+                if (currentToken != null && currentToken != requestToken) {
+                    return@withLock response.request.newBuilder()
+                        .header("Authorization", "Bearer $currentToken")
+                        .build()
                 }
 
-                response.request.newBuilder()
-                    .header("Authorization", "Bearer $tokenData")
-                    .build()
-            }.getOrElse {
-                dataStore.clearData()
-                null
+                // 토큰 갱신 로직
+                runCatching {
+                    val refreshToken = dataStore.getRefreshToken().first()
+                        ?: throw IllegalStateException("Refresh token is null")
+                    val tokenResponse = authService.refresh(RefreshTokenRequest(refreshToken))
+
+                    if (tokenResponse.statusCode != 200 && tokenResponse.data == null) {
+                        throw IllegalStateException("refreshToken 발급 실패")
+                    }
+                    val tokenData = tokenResponse.data?.accessToken
+                        ?: throw IllegalStateException("token is null")
+                    val newRefreshToken = tokenResponse.data.refreshToken
+
+                    withContext(Dispatchers.IO) {
+                        dataStore.saveAccessToken(tokenData)
+                        dataStore.saveRefreshToken(newRefreshToken)
+                    }
+
+                    response.request.newBuilder()
+                        .header("Authorization", "Bearer $tokenData")
+                        .build()
+                }.getOrElse {
+                    dataStore.clearData()
+                    null
+                }
             }
         }
     }
@@ -59,4 +79,5 @@ class TokenAuthenticator @Inject constructor(
         }
         return count
     }
+
 }


### PR DESCRIPTION
🔗 관련 이슈

📙 작업 설명
mutex를 이용해 401에러가 동시에 발생해도
순서대로 토큰을 발급받도록 설정

🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 동시 토큰 새로고침 요청 중 발생하는 인증 충돌을 방지했습니다.
  * 토큰 재사용 메커니즘을 추가하여 불필요한 새로고침을 줄였습니다.
  * 토큰 관리 프로세스의 동기화를 강화하여 인증 안정성을 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->