### PR TITLE
[ANDROID-163] 달력에서 빨간 점이 나오는것 오류 수정

### DIFF
--- a/core/ui/src/main/java/see/day/ui/calendar/DayCell.kt
+++ b/core/ui/src/main/java/see/day/ui/calendar/DayCell.kt
@@ -111,7 +111,7 @@ private fun PastDayImages(filterType: RecordType?, mainRecordType: RecordType?, 
                 )
             }
             // 점이 찍히는 조건
-            if (records.isNotEmpty()) {
+            if (records.size >= 2 || records.any { it.type != mainRecordType }) {
                 Image(
                     painter = painterResource(R.drawable.ic_red_dot),
                     modifier = Modifier
@@ -200,7 +200,7 @@ private fun TodayImages(filterType: RecordType?, mainRecordType: RecordType?, re
                 }
             }
             // 점이 찍히는 조건
-            if (records.isNotEmpty()) {
+            if (records.size >= 2 || records.any { it.type != mainRecordType }) {
                 Image(
                     painter = painterResource(R.drawable.ic_red_dot),
                     modifier = Modifier


### PR DESCRIPTION
빨간점은 기록필터가 ALL타입이고 기록이 2개이상이거나 메인 타입이 아닌 기록이 존재할 때 나온다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 캘린더 일정 셀의 빨간 점 표시기 표시 조건을 개선했습니다. 이제 여러 개의 일정이 있거나 다양한 유형의 일정이 섞여 있는 경우 더 명확하게 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->