### PR TITLE
[ANDROID-168] 세살 미만 가입 불가능하게 설정

### DIFF
--- a/feature/onboarding/src/main/java/see/day/onboarding/screen/onboarding/BirthdayScreen.kt
+++ b/feature/onboarding/src/main/java/see/day/onboarding/screen/onboarding/BirthdayScreen.kt
@@ -4,8 +4,6 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -27,9 +25,20 @@ import see.day.ui.picker.WheelPickerDefaults
 
 @Composable
 internal fun BirthdayScreen(modifier: Modifier = Modifier, birthDay: String, onClickComplete: (OnboardingUiEvent) -> Unit) {
-    var year by remember { mutableStateOf(birthDay.split("-")[0].toInt()) }
-    var month by remember { mutableStateOf(birthDay.split("-")[1].toInt()) }
-    var day by remember { mutableStateOf(birthDay.split("-")[2].toInt()) }
+    val initialDate = remember {
+        val threeYearsAgo = LocalDate.now().minusYears(3)
+        val parsedBirthDay = LocalDate.parse(birthDay)
+
+        if (parsedBirthDay.isAfter(threeYearsAgo)) {
+            threeYearsAgo
+        } else {
+            parsedBirthDay
+        }
+    }
+
+    var year by remember { mutableStateOf(initialDate.year) }
+    var month by remember { mutableStateOf(initialDate.monthValue) }
+    var day by remember { mutableStateOf(initialDate.dayOfMonth) }
 
     Column(
         modifier = modifier
@@ -45,7 +54,7 @@ internal fun BirthdayScreen(modifier: Modifier = Modifier, birthDay: String, onC
                 border = BorderStroke(0.dp, gray40)
             ),
             startDate = LocalDate.of(year, month, day),
-            maxDate = LocalDate.now(),
+            maxDate = LocalDate.now().minusYears(3),
             textStyle = MaterialTheme.typography.titleMedium,
             textColor = gray100
         ) { snappedDate ->
@@ -69,6 +78,17 @@ private fun BirthdayScreenPreview() {
     SeeDayTheme {
         BirthdayScreen(
             birthDay = "2025-09-09",
+            onClickComplete = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun BirthdayScreenBefore3YearsPreview() {
+    SeeDayTheme {
+        BirthdayScreen(
+            birthDay = "2000-01-01",
             onClickComplete = {}
         )
     }


### PR DESCRIPTION
🔗 관련 이슈

📙 작업 설명
세살 미만 불가능하게 설정
🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 생일 선택 화면의 날짜 범위를 개선했습니다. 최대 선택 가능 날짜가 3년 전으로 제한되어 사용자가 더욱 정확한 생일 정보를 입력할 수 있습니다.
  * 생일 날짜 초기화 로직을 최적화하여 다양한 입력 형식에 안정적으로 대응합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->