### PR TITLE
[QA-15] 캘린더 좌우 패딩 안맞음

### DIFF
--- a/core/ui/src/main/java/see/day/ui/calendar/CustomCalendar.kt
+++ b/core/ui/src/main/java/see/day/ui/calendar/CustomCalendar.kt
@@ -46,7 +46,7 @@ fun CustomCalendar(
     }
 
     Column(
-        modifier = modifier
+        modifier = modifier.padding(horizontal = 16.dp)
             .pointerInput(currentYear, currentMonth) {
                 var totalDragAmount = 0f
                 detectHorizontalDragGestures(


### PR DESCRIPTION
동일하게 좌우 16dp 패딩 줌

🔗 관련 이슈

📙 작업 설명
캘린더 좌우 패딩이 맞지 않기때문에
동일하게 16dp씩 준다.

🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)
<img width="648" height="1404" alt="image" src="https://github.com/user-attachments/assets/bc5a715b-dc4b-4800-ae11-394ca12172ad" />


💬 추가 설명 or 리뷰 포인트 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 캘린더의 간격이 조정되어 더욱 최적화된 레이아웃과 터치 반응성을 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->