### PR TITLE
[QA-14] 목표 리포트 화면에서 목표 재설정 버튼을 하단에 고정시킴

### DIFF
--- a/feature/goal/src/main/java/see/day/goal/screen/CurrentGoalScreen.kt
+++ b/feature/goal/src/main/java/see/day/goal/screen/CurrentGoalScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -139,8 +140,9 @@ internal fun CurrentGoalScreen(
                     dayStreak = uiState.dayStreak
                 )
                 if(uiState.isCompleted) {
+                    Spacer(modifier = Modifier.weight(1f))
                     ActionBanner(
-                        modifier = Modifier.fillMaxWidth().padding(top = 41.dp),
+                        modifier = Modifier.fillMaxWidth().padding(bottom = 4.dp).navigationBarsPadding(),
                         onClick = { onAction(CurrentGoalUiEvent.OnClickGoalBanner)},
                         title = see.day.ui.R.string.current_goal_banner_title,
                         body = see.day.ui.R.string.current_goal_banner_body


### PR DESCRIPTION
🔗 관련 이슈

📙 작업 설명
버튼을 하단에 일정부분 패딩을 주고 고정
🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **버그 수정**
  * 목표 완료 화면의 동작 배너 주변 간격을 개선했습니다.
  * 시스템 내비게이션 바와의 패딩 처리를 최적화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->