### PR TITLE
[ANDROID-180] 사진 삭제 그림자 재설정

### DIFF
--- a/core/ui/src/main/java/see/day/ui/photo/PhotoComponent.kt
+++ b/core/ui/src/main/java/see/day/ui/photo/PhotoComponent.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -12,7 +13,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -24,7 +27,7 @@ import see.day.ui.R
 @Composable
 fun PhotoComponent(modifier: Modifier = Modifier, uri: String, isRemovable: Boolean = false, onClickDeleteButton: (String) -> Unit = {}) {
     Box(
-        modifier = modifier.size(if (isRemovable) 106.dp else 100.dp).clip(RoundedCornerShape(8.dp))
+        modifier = modifier.size(if (isRemovable) 106.dp else 100.dp).clip(RoundedCornerShape(8.dp)).clipToBounds()
     ) {
         AsyncImage(
             model = uri,
@@ -42,9 +45,18 @@ fun PhotoComponent(modifier: Modifier = Modifier, uri: String, isRemovable: Bool
                 contentDescription = "닫기",
                 modifier = Modifier
                     .align(Alignment.TopEnd)
+                    .offset(x = 2.dp, y = (-2).dp)
                     .size(20.dp)
                     .clickable { onClickDeleteButton(uri) }
-                    .shadow(2.dp, CircleShape)
+                    .graphicsLayer {
+                        shadowElevation = 3.dp.toPx()
+                        translationX = 1.dp.toPx()  // 오른쪽으로
+                        translationY = 1.dp.toPx()  // 아래로
+                        shape = CircleShape
+                        clip = false
+                        ambientShadowColor = Color.Black.copy(alpha = 0.1f)
+                        spotShadowColor = Color.Black.copy(alpha = 0.15f)
+                    }
             )
         }
     }


### PR DESCRIPTION
🔗 관련 이슈

📙 작업 설명
사진 삭제 버튼의 그림자가 해상도가 떨어지고
피그마에 설정된 위치와는 다르게 설정되어있다

🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 스타일
  * 삭제 버튼의 그림자 효과와 시각적 표현이 개선되었습니다.
  * 삭제 아이콘의 위치 조정으로 더 나은 사용자 인터페이스를 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->