### PR TITLE
[ANDROID_204] feat: varients에 따라서 바라보는 서버 주소가 다르게 변경

### DIFF
--- a/build-logic/src/main/java/com/youth/app/KotlinAndroid.kt
+++ b/build-logic/src/main/java/com/youth/app/KotlinAndroid.kt
@@ -28,7 +28,6 @@ internal fun Project.configureKotlinAndroid() {
 
             testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-            buildConfigField("String","SERVER_API_KEY", getApiKey("server.api.key"))
             buildConfigField("String", "KAKAO_API_KEY", getApiKey("kakao.api.key"))
             addManifestPlaceholders(mapOf("KAKAO_API_KEY" to getApiKey("kakao.api.xml.key")))
         }
@@ -36,6 +35,10 @@ internal fun Project.configureKotlinAndroid() {
         buildTypes {
             getByName("release") {
                 proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+                buildConfigField("String","SERVER_API_KEY", getApiKey("prod.server.api.key"))
+            }
+            getByName("debug") {
+                buildConfigField("String","SERVER_API_KEY", getApiKey("stg.server.api.key"))
             }
         }
 


### PR DESCRIPTION
운영서버, 개발 서버로 분리

🔗 관련 이슈

📙 작업 설명
운영 서버에 영향을 최대한 덜 주려고
서버를 분리하였다.

🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 빌드 타입별 API 키 설정 분리 적용 (디버그 및 릴리스 환경에 맞게 구성)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->