### PR TITLE
[ANDROID-231] feat: 알림 설정 바텀 시트 작업

### DIFF
--- a/feature/schedule/src/main/java/see/day/schedule/component/AlertTimeBottomSheet.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/component/AlertTimeBottomSheet.kt
@@ -1,0 +1,233 @@
+package see.day.schedule.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import see.day.designsystem.theme.SeeDayTheme
+import see.day.designsystem.theme.Typography
+import see.day.designsystem.theme.gray100
+import see.day.designsystem.theme.gray20
+import see.day.designsystem.theme.gray30
+import see.day.schedule.R
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun AlertBottomSheet(
+    modifier: Modifier = Modifier,
+    checkedTime: AlertTime,
+    onDismiss: () -> Unit,
+    onCheckedChange: (AlertTime) -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val coroutineScope = rememberCoroutineScope()
+    var bottomSheetCheckedTime by remember { mutableStateOf(checkedTime) }
+    val dismissBottomSheet: () -> Unit = {
+        coroutineScope.launch {
+            sheetState.hide()
+            onDismiss()
+        }
+    }
+
+    Column(
+        modifier = modifier
+    ) {
+        ModalBottomSheet(
+            sheetState = sheetState,
+            onDismissRequest = dismissBottomSheet,
+            dragHandle = {},
+            containerColor = Color.White,
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .fillMaxHeight(0.9f)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        painter = painterResource(see.day.ui.R.drawable.ic_arrow_left),
+                        contentDescription = "뒤로 가기 버튼",
+                        tint = gray100,
+                        modifier = Modifier
+                            .size(24.dp)
+                            .clickable { dismissBottomSheet() },
+                    )
+
+                    Text(
+                        stringResource(R.string.alert_set),
+                        style = Typography.titleSmall,
+                    )
+                    Text(
+                        modifier = Modifier.clickable {
+                            onCheckedChange(bottomSheetCheckedTime)
+                            dismissBottomSheet()
+                        },
+                        text = stringResource(R.string.complete),
+                        style = Typography.titleSmall
+                    )
+                }
+                Column(
+                    modifier = Modifier
+                        .background(color = gray20)
+                        .fillMaxWidth()
+                        .weight(1f)
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 16.dp, start = 16.dp, end = 16.dp)
+                            .background(
+                                color = Color.White,
+                                shape = RoundedCornerShape(8.dp)
+                            )
+                    ) {
+                        AlertTime.entries.forEachIndexed { index, alertTime ->
+                            AlertText(
+                                checkedTime = bottomSheetCheckedTime,
+                                time = alertTime,
+                                onCheckedChange = { selectedTime ->
+                                    bottomSheetCheckedTime = selectedTime
+                                }
+                            )
+                            if (index < AlertTime.entries.lastIndex) {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(horizontal = 16.dp),
+                                    color = gray30,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlertText(
+    modifier: Modifier = Modifier,
+    checkedTime: AlertTime,
+    time: AlertTime,
+    onCheckedChange: (AlertTime) -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { onCheckedChange(time) }
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(time.textRes),
+                style = Typography.displayMedium,
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            // 조건부로 이 컬럼의 높이가 달라지는 문제 수정
+            Box(
+                modifier = Modifier.size(20.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                if (checkedTime == time) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_checked),
+                        contentDescription = "선택됨",
+                        tint = Color.Unspecified,
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun AlertTimeBottomSheetPreview() {
+    var checkedTime by remember { mutableStateOf(AlertTime.NO) }
+    var isBottomSheetOpen by remember { mutableStateOf(false) }
+
+    SeeDayTheme {
+        Column(
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Button(
+                onClick = { isBottomSheetOpen = true }
+            ) {
+                Text(text = "알림 설정 바텀시트")
+            }
+            Text(
+                text = "알림 설정 시간",
+                style = Typography.displayMedium,
+            )
+            Text(
+                text = stringResource(id = checkedTime.textRes),
+                style = Typography.displayMedium,
+            )
+        }
+
+        if (isBottomSheetOpen) {
+            AlertBottomSheet(
+                checkedTime = checkedTime,
+                onDismiss = { isBottomSheetOpen = false },
+                onCheckedChange = { checkedTime = it }
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun AlertTextPreview() {
+    var checkedTime by remember { mutableStateOf(AlertTime.ONE_HOUR) }
+
+    SeeDayTheme {
+        AlertText(
+            checkedTime = checkedTime,
+            time = AlertTime.ONE_HOUR,
+            onCheckedChange = { checkedTime = it }
+        )
+    }
+}
+
+enum class AlertTime(val textRes: Int) {
+    NO(R.string.alert_time_no), ONE_HOUR(R.string.alert_time_one_hour), TWO_HOUR(R.string.alert_time_two_hour), TWELVE_HOUR(R.string.alert_time_twelve_hour), ONE_DAY(R.string.alert_time_one_day)
+}

--- a/feature/schedule/src/main/java/see/day/schedule/screen/ScheduleScreenRoot.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/screen/ScheduleScreenRoot.kt
@@ -1,18 +1,54 @@
 package see.day.schedule.screen
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import see.day.designsystem.theme.SeeDayTheme
+import see.day.schedule.component.AlertBottomSheet
+import see.day.schedule.component.AlertTime
 
 @Composable
 fun ScheduleScreenRoot(onBack: () -> Unit, onClickPopHome: (Boolean) -> Unit) {
-    Text("Hello")
+    var showAlertBottomSheet by remember { mutableStateOf(false) }
+    var checkedTime by remember { mutableStateOf(AlertTime.NO) }
+
+    if (showAlertBottomSheet) {
+        AlertBottomSheet (
+            onDismiss = {
+                showAlertBottomSheet = false
+            },
+            checkedTime = checkedTime,
+            onCheckedChange = { checkedTime = it }
+        )
+    }
+    Column(
+        modifier = Modifier.systemBarsPadding()
+    ) {
+        Button(
+            onClick = {
+                showAlertBottomSheet = true
+            }
+        ) {
+            Text("알람 설정 바텀시트")
+        }
+        Text("반복 시간")
+        Text(stringResource(checkedTime.textRes))
+    }
 }
 
 @Preview
 @Composable
 private fun ScheduleScreenPreview() {
+    var checkedTime by remember { mutableStateOf(AlertTime.NO) }
     SeeDayTheme {
         ScheduleScreenRoot(
             onBack = {},

--- a/feature/schedule/src/main/res/drawable/ic_checked.xml
+++ b/feature/schedule/src/main/res/drawable/ic_checked.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M4,9.368L8.767,14L17,6"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.4"
+      android:fillColor="#00000000"
+      android:strokeColor="#212121"
+      android:strokeLineCap="round"/>
+</vector>

--- a/feature/schedule/src/main/res/values/strings.xml
+++ b/feature/schedule/src/main/res/values/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="alert_set">알림 설정</string>
+    <string name="complete">완료</string>
+    <string name="alert_time_no">알림 없음</string>
+    <string name="alert_time_one_hour">1시간 전</string>
+    <string name="alert_time_two_hour">2시간 전</string>
+    <string name="alert_time_twelve_hour">12시간 전</string>
+    <string name="alert_time_one_day">1일 전</string>
+</resources>


### PR DESCRIPTION
🔗 관련 이슈

📙 작업 설명
일정 기록의 경우 알림 시간을 설정할 수 있는데 해당 바텀 시트 작업을 진행했다.

🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 알림 시간 선택 기능 추가: 사용자가 없음, 1시간, 2시간, 12시간, 1일 중에서 알림 시간을 선택할 수 있습니다.
  * 일정 화면에 알림 시간 설정 버튼 추가: 선택된 알림 시간이 화면에 표시되고 업데이트됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->