### PR TITLE
[ANDROID-236] feat: 일정 UI 쪼개기

### DIFF
--- a/core/ui/src/main/java/see/day/ui/textField/RecordWriteTextField.kt
+++ b/core/ui/src/main/java/see/day/ui/textField/RecordWriteTextField.kt
@@ -39,9 +39,7 @@ fun RecordWriteTextField(modifier: Modifier = Modifier, text: String, @StringRes
         BasicTextField(
             value = text,
             onValueChange = { newValue ->
-                if(newValue.length <= 1000) {
-                    onChangedText(newValue)
-                }
+                onChangedText(newValue.take(1000))
 
             },
             textStyle = MaterialTheme.typography.displayMedium.copy(color = gray100),

--- a/feature/schedule/src/main/java/see/day/schedule/component/AlertSetting.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/component/AlertSetting.kt
@@ -1,0 +1,79 @@
+package see.day.schedule.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import see.day.designsystem.theme.gray70
+import see.day.schedule.R
+
+@Composable
+internal fun AlertSetting(
+    modifier: Modifier = Modifier,
+    checkedTime: AlertTime,
+    onCheckedTimeChange: (AlertTime) -> Unit,
+) {
+    var isShowAlertBottomSheet by remember { mutableStateOf(false) }
+
+    if (isShowAlertBottomSheet) {
+        AlertBottomSheet(
+            onDismiss = {
+                isShowAlertBottomSheet = false
+            },
+            checkedTime = checkedTime,
+            onCheckedChange = onCheckedTimeChange
+        )
+    }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable {
+                isShowAlertBottomSheet = true
+            },
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_notification),
+            contentDescription = "알림 설정",
+            modifier = Modifier.size(24.dp),
+            tint = Color.Unspecified
+        )
+        Text(
+            modifier = Modifier.padding(start = 6.dp),
+            text = "알림",
+            style = MaterialTheme.typography.titleSmall
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        Text(
+            text = stringResource(checkedTime.textRes),
+            style = MaterialTheme.typography.labelSmall.copy(
+                color = gray70
+            )
+        )
+        Icon(
+            painter = painterResource(see.day.ui.R.drawable.ic_arrow_right),
+            contentDescription = "알림 설정",
+            modifier = Modifier
+                .size(20.dp)
+                .padding(start = 6.dp),
+            tint = Color.Unspecified
+        )
+    }
+}

--- a/feature/schedule/src/main/java/see/day/schedule/component/AlertSetting.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/component/AlertSetting.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import see.day.designsystem.theme.gray70
 import see.day.schedule.R
+import see.day.schedule.component.bottomsheet.AlertBottomSheet
+import see.day.schedule.component.bottomsheet.AlertTime
 
 @Composable
 internal fun AlertSetting(

--- a/feature/schedule/src/main/java/see/day/schedule/component/CalendarSetting.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/component/CalendarSetting.kt
@@ -1,0 +1,178 @@
+package see.day.schedule.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import see.day.designsystem.theme.gray100
+import see.day.designsystem.theme.gray20
+import see.day.designsystem.theme.gray40
+import see.day.designsystem.theme.gray50
+import see.day.schedule.R
+import see.day.schedule.screen.toDateString
+import see.day.ui.picker.WheelDatePicker
+import see.day.ui.picker.WheelPickerDefaults
+import java.time.LocalDate
+
+@Composable
+internal fun CalendarSetting(
+    modifier: Modifier = Modifier,
+    startDate: LocalDate,
+    endDate: LocalDate,
+    setStartDate: (LocalDate) -> Unit,
+    setEndDate: (LocalDate) -> Unit
+) {
+    var isShowStartDatePicker by remember { mutableStateOf(false) }
+    var isShowEndDatePicker by remember { mutableStateOf(false) }
+
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_calendar),
+            contentDescription = "달력 아이콘",
+            modifier = Modifier.size(24.dp),
+            tint = Color.Unspecified
+        )
+        Text(
+            modifier = Modifier.padding(start = 6.dp),
+            text = stringResource(R.string.calendar),
+            style = MaterialTheme.typography.titleSmall
+        )
+    }
+    Row(
+        modifier = Modifier
+            .padding(top = 16.dp)
+            .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        ScheduleDateText(
+            date = startDate,
+            isClicked = isShowStartDatePicker,
+            onClickDate = {
+                if (!isShowStartDatePicker) {
+                    isShowStartDatePicker = true
+                }
+                if (isShowEndDatePicker) {
+                    isShowEndDatePicker = false
+                }
+            }
+        )
+        Icon(
+            painter = painterResource(see.day.ui.R.drawable.ic_arrow_right),
+            contentDescription = "체크 아이콘",
+            modifier = Modifier.size(24.dp),
+            tint = Color.Unspecified
+        )
+        ScheduleDateText(
+            date = endDate,
+            isClicked = isShowEndDatePicker,
+            onClickDate = {
+                if (!isShowEndDatePicker) {
+                    isShowEndDatePicker = true
+                }
+                if (isShowStartDatePicker) {
+                    isShowStartDatePicker = false
+                }
+            }
+        )
+    }
+
+    if (isShowStartDatePicker || isShowEndDatePicker) {
+        val selectedDatePickerKey = if (isShowStartDatePicker) "start" else "end"
+
+        key(selectedDatePickerKey) {
+            WheelDatePicker(
+                modifier = Modifier
+                    .padding(top = 16.dp)
+                    .fillMaxWidth()
+                    .height(170.dp),
+                rowCount = 5,
+                selectorProperties = WheelPickerDefaults.selectorProperties(
+                    color = gray40,
+                    shape = RoundedCornerShape(0),
+                    border = BorderStroke(0.dp, gray40)
+                ),
+                startDate = if (isShowStartDatePicker) startDate else endDate,
+                minDate = if (isShowStartDatePicker) LocalDate.MIN else startDate,
+                maxDate = LocalDate.MAX,
+                textStyle = MaterialTheme.typography.titleMedium,
+                textColor = gray100
+            ) { snappedDate ->
+                if (isShowStartDatePicker) {
+                    setStartDate(snappedDate)
+                    if (snappedDate > endDate) {
+                        setEndDate(snappedDate)
+                    }
+                }
+                if (isShowEndDatePicker) {
+                    setEndDate(snappedDate)
+                }
+            }
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End
+        ) {
+            Text(
+                modifier = Modifier
+                    .padding(top = 10.dp)
+                    .clickable {
+                        isShowStartDatePicker = false
+                        isShowEndDatePicker = false
+                    },
+                text = "완료",
+                style = MaterialTheme.typography.titleSmall,
+                color = gray100
+            )
+        }
+    }
+}
+
+@Composable
+private fun ScheduleDateText(
+    date: LocalDate,
+    isClicked: Boolean,
+    onClickDate: () -> Unit,
+) {
+
+    Box(
+        modifier = Modifier
+            .size(height = 40.dp, width = 148.dp)
+            .clickable { onClickDate() }
+            .background(gray20, RoundedCornerShape(8.dp))
+            .padding(horizontal = 14.dp),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        Text(
+            text = date.toDateString(),
+            style = MaterialTheme.typography.titleSmall.copy(
+                color = if (isClicked) gray100 else gray50
+            )
+        )
+    }
+}

--- a/feature/schedule/src/main/java/see/day/schedule/component/ColorSetting.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/component/ColorSetting.kt
@@ -1,0 +1,80 @@
+package see.day.schedule.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import see.day.schedule.R
+
+@Composable
+internal fun ColorSetting(
+    modifier: Modifier = Modifier,
+    selectedColor: Color,
+    onColorChange: (Color) -> Unit,
+) {
+    var isShowColorBottomSheet by remember { mutableStateOf(false) }
+
+    if (isShowColorBottomSheet) {
+        ColorPaletteBottomSheet(
+            selectedColor = selectedColor,
+            onColorSelected = onColorChange,
+            onDismiss = {
+                isShowColorBottomSheet = false
+            }
+        )
+    }
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable {
+                isShowColorBottomSheet = true
+            },
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_palette),
+            contentDescription = "색상 설정",
+            modifier = Modifier.size(24.dp),
+            tint = Color.Unspecified
+        )
+        Text(
+            modifier = Modifier.padding(start = 6.dp),
+            text = "색상",
+            style = MaterialTheme.typography.titleSmall
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        Box(
+            modifier = Modifier
+                .size(20.dp)
+                .background(selectedColor, shape = CircleShape),
+            contentAlignment = Alignment.Center
+        ) {
+        }
+        Icon(
+            painter = painterResource(see.day.ui.R.drawable.ic_arrow_right),
+            contentDescription = "색상 설정",
+            modifier = Modifier
+                .size(20.dp)
+                .padding(start = 6.dp),
+            tint = Color.Unspecified
+        )
+    }
+}

--- a/feature/schedule/src/main/java/see/day/schedule/component/ColorSetting.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/component/ColorSetting.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import see.day.schedule.R
+import see.day.schedule.component.bottomsheet.ColorPaletteBottomSheet
 
 @Composable
 internal fun ColorSetting(

--- a/feature/schedule/src/main/java/see/day/schedule/component/LocationSetting.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/component/LocationSetting.kt
@@ -1,0 +1,75 @@
+package see.day.schedule.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import see.day.designsystem.theme.gray50
+import see.day.schedule.R
+
+@Composable
+internal fun LocationSetting(
+    modifier: Modifier = Modifier,
+    locationText: String,
+    onLocationChange: (String) -> Unit
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_compass),
+            contentDescription = "위치 설정",
+            modifier = Modifier.size(24.dp),
+            tint = Color.Unspecified
+        )
+        Text(
+            modifier = Modifier.padding(start = 6.dp),
+            text = stringResource(id = R.string.location),
+            style = MaterialTheme.typography.titleSmall,
+        )
+        BasicTextField(
+            modifier = Modifier
+                .padding(start = 10.dp)
+                .height(height = 52.dp)
+                .fillMaxWidth()
+                .background(Color.White)
+                .padding(horizontal = 14.dp),
+            value = locationText,
+            textStyle = MaterialTheme.typography.displayMedium,
+            maxLines = 1,
+            onValueChange = onLocationChange,
+            decorationBox = { innerTextField ->
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.CenterStart
+                ) {
+                    if (locationText.isEmpty()) {
+                        Text(
+                            text = stringResource(id = R.string.location_hint),
+                            style = MaterialTheme.typography.displayMedium,
+                            color = gray50
+                        )
+                    }
+                    innerTextField()
+                }
+            }
+        )
+    }
+}

--- a/feature/schedule/src/main/java/see/day/schedule/component/MemoSetting.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/component/MemoSetting.kt
@@ -54,9 +54,7 @@ internal fun MemoSetting(modifier: Modifier = Modifier, text: String, onChangedT
         BasicTextField(
             value = text,
             onValueChange = { newValue ->
-                if(newValue.length <= 1000) {
-                    onChangedText(newValue)
-                }
+                onChangedText(newValue.take(1000))
             },
             textStyle = MaterialTheme.typography.displayMedium.copy(color = gray100),
             modifier = Modifier

--- a/feature/schedule/src/main/java/see/day/schedule/component/MemoSetting.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/component/MemoSetting.kt
@@ -1,0 +1,86 @@
+package see.day.schedule.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import see.day.designsystem.theme.gray100
+import see.day.designsystem.theme.gray20
+import see.day.designsystem.theme.gray50
+import see.day.designsystem.theme.gray60
+import see.day.schedule.R
+
+@Composable
+internal fun MemoSetting(modifier: Modifier = Modifier, text: String, onChangedText: (String) -> Unit) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.Bottom
+    ) {
+        Image(
+            painter = painterResource(R.drawable.ic_article),
+            contentDescription = stringResource(R.string.memo),
+            modifier = Modifier.size(24.dp)
+        )
+        Text(
+            text = stringResource(R.string.memo),
+            style = MaterialTheme.typography.titleSmall,
+            modifier = Modifier.padding(start = 6.dp)
+        )
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(251.dp)
+            .padding(top = 10.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(gray20)
+    ) {
+        BasicTextField(
+            value = text,
+            onValueChange = { newValue ->
+                if(newValue.length <= 1000) {
+                    onChangedText(newValue)
+                }
+            },
+            textStyle = MaterialTheme.typography.displayMedium.copy(color = gray100),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 14.dp)
+                .padding(top = 14.dp, bottom = 45.dp),
+            decorationBox = { innerTextField ->
+                if (text.isEmpty()) {
+                    Text(
+                        text = "메모",
+                        style = MaterialTheme.typography.displayMedium,
+                        color = gray50
+                    )
+                }
+                innerTextField()
+            }
+        )
+        Text(
+            text = "${text.length} / 1000",
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(end = 14.dp, bottom = 14.dp),
+            color = if (text.isEmpty()) gray60 else gray100
+        )
+    }
+}

--- a/feature/schedule/src/main/java/see/day/schedule/component/RepeatSetting.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/component/RepeatSetting.kt
@@ -1,0 +1,83 @@
+package see.day.schedule.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import see.day.designsystem.theme.gray70
+import see.day.schedule.R
+import java.time.LocalDate
+
+@Composable
+internal fun RepeatSetting(
+    modifier: Modifier = Modifier,
+    startDate: LocalDate,
+    repeatTime: RepeatTime,
+    repeatEndTime: RepeatEndTime?,
+    onCheckedChange: (RepeatTime, RepeatEndTime?) -> Unit,
+) {
+    var isShowRepeatBottomSheet by remember { mutableStateOf(false) }
+
+    if (isShowRepeatBottomSheet) {
+        RepeatTimeBottomSheet(
+            startDate = startDate,
+            repeatTime = repeatTime,
+            repeatEndTime = repeatEndTime,
+            onCheckedChange = onCheckedChange,
+            onDismiss = {
+                isShowRepeatBottomSheet = false
+            }
+        )
+    }
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable {
+                isShowRepeatBottomSheet = true
+            },
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_repeat),
+            contentDescription = "반복 설정",
+            modifier = Modifier.size(24.dp),
+            tint = Color.Unspecified
+        )
+        Text(
+            modifier = Modifier.padding(start = 6.dp),
+            text = "반복",
+            style = MaterialTheme.typography.titleSmall
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        Text(
+            text = stringResource(repeatTime.textRes) + if (repeatEndTime != null) ", ${repeatEndTime.dateStr} 종료" else "",
+            style = MaterialTheme.typography.labelSmall.copy(
+                color = gray70
+            )
+        )
+        Icon(
+            painter = painterResource(see.day.ui.R.drawable.ic_arrow_right),
+            contentDescription = "반복 설정",
+            modifier = Modifier
+                .size(20.dp)
+                .padding(start = 6.dp),
+            tint = Color.Unspecified
+        )
+    }
+}

--- a/feature/schedule/src/main/java/see/day/schedule/component/RepeatSetting.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/component/RepeatSetting.kt
@@ -22,6 +22,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import see.day.designsystem.theme.gray70
 import see.day.schedule.R
+import see.day.schedule.component.bottomsheet.RepeatEndTime
+import see.day.schedule.component.bottomsheet.RepeatTime
+import see.day.schedule.component.bottomsheet.RepeatTimeBottomSheet
 import java.time.LocalDate
 
 @Composable

--- a/feature/schedule/src/main/java/see/day/schedule/component/bottomsheet/AlertTimeBottomSheet.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/component/bottomsheet/AlertTimeBottomSheet.kt
@@ -1,4 +1,4 @@
-package see.day.schedule.component
+package see.day.schedule.component.bottomsheet
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable

--- a/feature/schedule/src/main/java/see/day/schedule/component/bottomsheet/ColorPaletteBottomSheet.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/component/bottomsheet/ColorPaletteBottomSheet.kt
@@ -1,4 +1,4 @@
-package see.day.schedule.component
+package see.day.schedule.component.bottomsheet
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable

--- a/feature/schedule/src/main/java/see/day/schedule/component/bottomsheet/RepeatTimeBottomSheet.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/component/bottomsheet/RepeatTimeBottomSheet.kt
@@ -1,4 +1,4 @@
-package see.day.schedule.component
+package see.day.schedule.component.bottomsheet
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn

--- a/feature/schedule/src/main/java/see/day/schedule/screen/ScheduleScreenRoot.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/screen/ScheduleScreenRoot.kt
@@ -53,6 +53,7 @@ import see.day.schedule.component.AlertSetting
 import see.day.schedule.component.AlertTime
 import see.day.schedule.component.CalendarSetting
 import see.day.schedule.component.ColorPaletteBottomSheet
+import see.day.schedule.component.LocationSetting
 import see.day.schedule.component.RepeatEndTime
 import see.day.schedule.component.RepeatSetting
 import see.day.schedule.component.RepeatTime
@@ -185,7 +186,11 @@ internal fun ScheduleDetailScreen(
                     .height(1.dp)
                     .background(gray30),
             )
-            LocationSetting(locationText, onLocationChange)
+            LocationSetting(
+                modifier = Modifier.padding(top = 10.dp),
+                locationText = locationText,
+                onLocationChange = onLocationChange,
+            )
             Spacer(
                 modifier = Modifier
                     .padding(top = 10.dp)
@@ -239,58 +244,6 @@ private fun ScheduleTitle(
                     if (scheduleTitle.isEmpty()) {
                         Text(
                             text = stringResource(id = R.string.schedule_hint),
-                            style = MaterialTheme.typography.displayMedium,
-                            color = gray50
-                        )
-                    }
-                    innerTextField()
-                }
-            }
-        )
-    }
-}
-
-@Composable
-private fun LocationSetting(
-    locationText: String,
-    onLocationChange: (String) -> Unit
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 10.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Icon(
-            painter = painterResource(R.drawable.ic_compass),
-            contentDescription = "위치 설정",
-            modifier = Modifier.size(24.dp),
-            tint = Color.Unspecified
-        )
-        Text(
-            modifier = Modifier.padding(start = 6.dp),
-            text = stringResource(id = R.string.location),
-            style = MaterialTheme.typography.titleSmall,
-        )
-        BasicTextField(
-            modifier = Modifier
-                .padding(start = 10.dp)
-                .height(height = 52.dp)
-                .fillMaxWidth()
-                .background(Color.White)
-                .padding(horizontal = 14.dp),
-            value = locationText,
-            textStyle = MaterialTheme.typography.displayMedium,
-            maxLines = 1,
-            onValueChange = onLocationChange,
-            decorationBox = { innerTextField ->
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.CenterStart
-                ) {
-                    if (locationText.isEmpty()) {
-                        Text(
-                            text = stringResource(id = R.string.location_hint),
                             style = MaterialTheme.typography.displayMedium,
                             color = gray50
                         )

--- a/feature/schedule/src/main/java/see/day/schedule/screen/ScheduleScreenRoot.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/screen/ScheduleScreenRoot.kt
@@ -2,7 +2,6 @@ package see.day.schedule.screen
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -17,11 +16,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -42,23 +39,19 @@ import see.day.designsystem.theme.SeeDayTheme
 import see.day.designsystem.theme.gray100
 import see.day.designsystem.theme.gray20
 import see.day.designsystem.theme.gray30
-import see.day.designsystem.theme.gray40
 import see.day.designsystem.theme.gray50
 import see.day.designsystem.theme.gray60
-import see.day.designsystem.theme.gray70
 import see.day.designsystem.theme.primaryColor
 import see.day.schedule.R
-import see.day.schedule.component.AlertBottomSheet
 import see.day.schedule.component.AlertSetting
 import see.day.schedule.component.AlertTime
 import see.day.schedule.component.CalendarSetting
-import see.day.schedule.component.ColorPaletteBottomSheet
 import see.day.schedule.component.ColorSetting
 import see.day.schedule.component.LocationSetting
+import see.day.schedule.component.MemoSetting
 import see.day.schedule.component.RepeatEndTime
 import see.day.schedule.component.RepeatSetting
 import see.day.schedule.component.RepeatTime
-import see.day.schedule.component.RepeatTimeBottomSheet
 import see.day.schedule.component.ScheduleTopBar
 import see.day.ui.button.CompleteButton
 import java.time.LocalDate
@@ -204,7 +197,8 @@ internal fun ScheduleDetailScreen(
                 selectedColor = checkedColor,
                 onColorChange = onColorChange,
             )
-            MemoTextField(
+            MemoSetting(
+                modifier = Modifier.padding(top = 16.dp),
                 text = memoText,
                 onChangedText = onMemoChange,
             )
@@ -253,65 +247,6 @@ private fun ScheduleTitle(
                     innerTextField()
                 }
             }
-        )
-    }
-}
-
-@Composable
-fun MemoTextField(modifier: Modifier = Modifier, text: String, onChangedText: (String) -> Unit) {
-    Row(
-        modifier = Modifier.padding(top = 16.dp),
-        verticalAlignment = Alignment.Bottom
-    ) {
-        Image(
-            painter = painterResource(R.drawable.ic_article),
-            contentDescription = stringResource(R.string.memo),
-            modifier = Modifier.size(24.dp)
-        )
-        Text(
-            text = stringResource(R.string.memo),
-            style = MaterialTheme.typography.titleSmall,
-            modifier = Modifier.padding(start = 6.dp)
-        )
-    }
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(251.dp)
-            .padding(top = 10.dp)
-            .clip(RoundedCornerShape(8.dp))
-            .background(gray20)
-    ) {
-        BasicTextField(
-            value = text,
-            onValueChange = { newValue ->
-                if(newValue.length <= 1000) {
-                    onChangedText(newValue)
-                }
-            },
-            textStyle = MaterialTheme.typography.displayMedium.copy(color = gray100),
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = 14.dp)
-                .padding(top = 14.dp, bottom = 45.dp),
-            decorationBox = { innerTextField ->
-                if (text.isEmpty()) {
-                    Text(
-                        text = "메모",
-                        style = MaterialTheme.typography.displayMedium,
-                        color = gray50
-                    )
-                }
-                innerTextField()
-            }
-        )
-        Text(
-            text = "${text.length} / 1000",
-            style = MaterialTheme.typography.labelSmall,
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(end = 14.dp, bottom = 14.dp),
-            color = if (text.isEmpty()) gray60 else gray100
         )
     }
 }

--- a/feature/schedule/src/main/java/see/day/schedule/screen/ScheduleScreenRoot.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/screen/ScheduleScreenRoot.kt
@@ -1,6 +1,5 @@
 package see.day.schedule.screen
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -31,27 +30,24 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import see.day.designsystem.theme.SeeDayTheme
-import see.day.designsystem.theme.gray100
 import see.day.designsystem.theme.gray20
 import see.day.designsystem.theme.gray30
 import see.day.designsystem.theme.gray50
-import see.day.designsystem.theme.gray60
 import see.day.designsystem.theme.primaryColor
 import see.day.schedule.R
 import see.day.schedule.component.AlertSetting
-import see.day.schedule.component.AlertTime
+import see.day.schedule.component.bottomsheet.AlertTime
 import see.day.schedule.component.CalendarSetting
 import see.day.schedule.component.ColorSetting
 import see.day.schedule.component.LocationSetting
 import see.day.schedule.component.MemoSetting
-import see.day.schedule.component.RepeatEndTime
+import see.day.schedule.component.bottomsheet.RepeatEndTime
 import see.day.schedule.component.RepeatSetting
-import see.day.schedule.component.RepeatTime
+import see.day.schedule.component.bottomsheet.RepeatTime
 import see.day.schedule.component.ScheduleTopBar
 import see.day.ui.button.CompleteButton
 import java.time.LocalDate

--- a/feature/schedule/src/main/java/see/day/schedule/screen/ScheduleScreenRoot.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/screen/ScheduleScreenRoot.kt
@@ -1,10 +1,8 @@
 package see.day.schedule.screen
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -29,7 +27,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -53,14 +50,13 @@ import see.day.designsystem.theme.primaryColor
 import see.day.schedule.R
 import see.day.schedule.component.AlertBottomSheet
 import see.day.schedule.component.AlertTime
+import see.day.schedule.component.CalendarSetting
 import see.day.schedule.component.ColorPaletteBottomSheet
 import see.day.schedule.component.RepeatEndTime
 import see.day.schedule.component.RepeatTime
 import see.day.schedule.component.RepeatTimeBottomSheet
 import see.day.schedule.component.ScheduleTopBar
 import see.day.ui.button.CompleteButton
-import see.day.ui.picker.WheelDatePicker
-import see.day.ui.picker.WheelPickerDefaults
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -162,6 +158,7 @@ internal fun ScheduleDetailScreen(
             // 색상하고 일정명 텍스트 필드
             ScheduleTitle(checkedColor, scheduleTitle, onScheduleTitleChange)
             CalendarSetting(
+                modifier = Modifier.padding(top = 10.dp),
                 startDate = startDate,
                 endDate = endDate,
                 setStartDate = onStartDateChange,
@@ -249,147 +246,6 @@ private fun ScheduleTitle(
     }
 }
 
-@Composable
-private fun CalendarSetting(
-    modifier: Modifier = Modifier,
-    startDate: LocalDate,
-    endDate: LocalDate,
-    setStartDate: (LocalDate) -> Unit,
-    setEndDate: (LocalDate) -> Unit
-) {
-    var isShowStartDatePicker by remember { mutableStateOf(false) }
-    var isShowEndDatePicker by remember { mutableStateOf(false) }
-
-
-    Row(
-        modifier = Modifier.padding(top = 10.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Icon(
-            painter = painterResource(R.drawable.ic_calendar),
-            contentDescription = "달력 아이콘",
-            modifier = Modifier.size(24.dp),
-            tint = Color.Unspecified
-        )
-        Text(
-            modifier = Modifier.padding(start = 6.dp),
-            text = stringResource(R.string.calendar),
-            style = MaterialTheme.typography.titleSmall
-        )
-    }
-    Row(
-        modifier = Modifier
-            .padding(top = 16.dp)
-            .fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween,
-    ) {
-        ScheduleDateText(
-            date = startDate,
-            isClicked = isShowStartDatePicker,
-            onClickDate = {
-                if (!isShowStartDatePicker) {
-                    isShowStartDatePicker = true
-                }
-                if (isShowEndDatePicker) {
-                    isShowEndDatePicker = false
-                }
-            }
-        )
-        Icon(
-            painter = painterResource(see.day.ui.R.drawable.ic_arrow_right),
-            contentDescription = "체크 아이콘",
-            modifier = Modifier.size(24.dp),
-            tint = Color.Unspecified
-        )
-        ScheduleDateText(
-            date = endDate,
-            isClicked = isShowEndDatePicker,
-            onClickDate = {
-                if (!isShowEndDatePicker) {
-                    isShowEndDatePicker = true
-                }
-                if (isShowStartDatePicker) {
-                    isShowStartDatePicker = false
-                }
-            }
-        )
-    }
-
-    if (isShowStartDatePicker || isShowEndDatePicker) {
-        val selectedDatePickerKey = if (isShowStartDatePicker) "start" else "end"
-
-        key(selectedDatePickerKey) {
-            WheelDatePicker(
-                modifier = Modifier
-                    .padding(top = 16.dp)
-                    .fillMaxWidth()
-                    .height(170.dp),
-                rowCount = 5,
-                selectorProperties = WheelPickerDefaults.selectorProperties(
-                    color = gray40,
-                    shape = RoundedCornerShape(0),
-                    border = BorderStroke(0.dp, gray40)
-                ),
-                startDate = if (isShowStartDatePicker) startDate else endDate,
-                minDate = if (isShowStartDatePicker) LocalDate.MIN else startDate,
-                maxDate = LocalDate.MAX,
-                textStyle = MaterialTheme.typography.titleMedium,
-                textColor = gray100
-            ) { snappedDate ->
-                if (isShowStartDatePicker) {
-                    setStartDate(snappedDate)
-                    if (snappedDate > endDate) {
-                        setEndDate(snappedDate)
-                    }
-                }
-                if (isShowEndDatePicker) {
-                    setEndDate(snappedDate)
-                }
-            }
-        }
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.End
-        ) {
-            Text(
-                modifier = Modifier
-                    .padding(top = 10.dp)
-                    .clickable {
-                        isShowStartDatePicker = false
-                        isShowEndDatePicker = false
-                    },
-                text = "완료",
-                style = MaterialTheme.typography.titleSmall,
-                color = gray100
-            )
-        }
-    }
-}
-
-@Composable
-private fun ScheduleDateText(
-    date: LocalDate,
-    isClicked: Boolean,
-    onClickDate: () -> Unit,
-) {
-
-    Box(
-        modifier = Modifier
-            .size(height = 40.dp, width = 148.dp)
-            .clickable { onClickDate() }
-            .background(gray20, RoundedCornerShape(8.dp))
-            .padding(horizontal = 14.dp),
-        contentAlignment = Alignment.CenterStart
-    ) {
-        Text(
-            text = date.toDateString(),
-            style = MaterialTheme.typography.titleSmall.copy(
-                color = if (isClicked) gray100 else gray50
-            )
-        )
-    }
-}
 
 @Composable
 private fun AlertSetting(

--- a/feature/schedule/src/main/java/see/day/schedule/screen/ScheduleScreenRoot.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/screen/ScheduleScreenRoot.kt
@@ -49,6 +49,7 @@ import see.day.designsystem.theme.gray70
 import see.day.designsystem.theme.primaryColor
 import see.day.schedule.R
 import see.day.schedule.component.AlertBottomSheet
+import see.day.schedule.component.AlertSetting
 import see.day.schedule.component.AlertTime
 import see.day.schedule.component.CalendarSetting
 import see.day.schedule.component.ColorPaletteBottomSheet
@@ -165,6 +166,7 @@ internal fun ScheduleDetailScreen(
                 setEndDate = onEndDateChange,
             )
             AlertSetting(
+                modifier = Modifier.padding(top = 16.dp),
                 checkedTime = checkedTime,
                 onCheckedTimeChange = onCheckedTimeChange
             )
@@ -242,62 +244,6 @@ private fun ScheduleTitle(
                     innerTextField()
                 }
             }
-        )
-    }
-}
-
-
-@Composable
-private fun AlertSetting(
-    checkedTime: AlertTime,
-    onCheckedTimeChange: (AlertTime) -> Unit,
-) {
-    var isShowAlertBottomSheet by remember { mutableStateOf(false) }
-
-    if (isShowAlertBottomSheet) {
-        AlertBottomSheet(
-            onDismiss = {
-                isShowAlertBottomSheet = false
-            },
-            checkedTime = checkedTime,
-            onCheckedChange = onCheckedTimeChange
-        )
-    }
-
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 16.dp)
-            .clickable {
-                isShowAlertBottomSheet = true
-            },
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Icon(
-            painter = painterResource(R.drawable.ic_notification),
-            contentDescription = "알림 설정",
-            modifier = Modifier.size(24.dp),
-            tint = Color.Unspecified
-        )
-        Text(
-            modifier = Modifier.padding(start = 6.dp),
-            text = "알림",
-            style = MaterialTheme.typography.titleSmall
-        )
-        Spacer(modifier = Modifier.weight(1f))
-        Text(
-            text = stringResource(checkedTime.textRes),
-            style = MaterialTheme.typography.labelSmall.copy(
-                color = gray70
-            )
-        )
-        Icon(
-            painter = painterResource(see.day.ui.R.drawable.ic_arrow_right),
-            contentDescription = "알림 설정",
-            modifier = Modifier
-                .size(20.dp)
-                .padding(start = 6.dp),
-            tint = Color.Unspecified
         )
     }
 }

--- a/feature/schedule/src/main/java/see/day/schedule/screen/ScheduleScreenRoot.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/screen/ScheduleScreenRoot.kt
@@ -53,6 +53,7 @@ import see.day.schedule.component.AlertSetting
 import see.day.schedule.component.AlertTime
 import see.day.schedule.component.CalendarSetting
 import see.day.schedule.component.ColorPaletteBottomSheet
+import see.day.schedule.component.ColorSetting
 import see.day.schedule.component.LocationSetting
 import see.day.schedule.component.RepeatEndTime
 import see.day.schedule.component.RepeatSetting
@@ -199,6 +200,7 @@ internal fun ScheduleDetailScreen(
                     .background(gray30),
             )
             ColorSetting(
+                modifier = Modifier.padding(top = 24.dp),
                 selectedColor = checkedColor,
                 onColorChange = onColorChange,
             )
@@ -251,61 +253,6 @@ private fun ScheduleTitle(
                     innerTextField()
                 }
             }
-        )
-    }
-}
-
-@Composable
-private fun ColorSetting(
-    selectedColor: Color,
-    onColorChange: (Color) -> Unit,
-) {
-    var isShowColorBottomSheet by remember { mutableStateOf(false) }
-
-    if (isShowColorBottomSheet) {
-        ColorPaletteBottomSheet(
-            selectedColor = selectedColor,
-            onColorSelected = onColorChange,
-            onDismiss = {
-                isShowColorBottomSheet = false
-            }
-        )
-    }
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 24.dp)
-            .clickable {
-                isShowColorBottomSheet = true
-            },
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Icon(
-            painter = painterResource(R.drawable.ic_palette),
-            contentDescription = "색상 설정",
-            modifier = Modifier.size(24.dp),
-            tint = Color.Unspecified
-        )
-        Text(
-            modifier = Modifier.padding(start = 6.dp),
-            text = "색상",
-            style = MaterialTheme.typography.titleSmall
-        )
-        Spacer(modifier = Modifier.weight(1f))
-        Box(
-            modifier = Modifier
-                .size(20.dp)
-                .background(selectedColor, shape = CircleShape),
-            contentAlignment = Alignment.Center
-        ) {
-        }
-        Icon(
-            painter = painterResource(see.day.ui.R.drawable.ic_arrow_right),
-            contentDescription = "색상 설정",
-            modifier = Modifier
-                .size(20.dp)
-                .padding(start = 6.dp),
-            tint = Color.Unspecified
         )
     }
 }

--- a/feature/schedule/src/main/java/see/day/schedule/screen/ScheduleScreenRoot.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/screen/ScheduleScreenRoot.kt
@@ -50,6 +50,7 @@ import see.day.schedule.component.RepeatSetting
 import see.day.schedule.component.bottomsheet.RepeatTime
 import see.day.schedule.component.ScheduleTopBar
 import see.day.ui.button.CompleteButton
+import timber.log.Timber
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -138,7 +139,17 @@ internal fun ScheduleDetailScreen(
                 text = stringResource(see.day.ui.R.string.write_record_text),
                 isEnabled = scheduleTitle.isNotBlank(),
                 onClick = {
-                    // TODO 클릭시 이벤트 필요
+                    Timber.d(
+                        "scheduleTitle: $scheduleTitle\n" +
+                            "checkedColor: $checkedColor\n" +
+                            "startDate: $startDate\n" +
+                            "endDate: $endDate\n" +
+                            "checkedTime: $checkedTime\n" +
+                            "repeatTime: $repeatTime\n" +
+                            "repeatEndTime: $repeatEndTime\n" +
+                            "locationText: $locationText\n" +
+                            "memoText: $memoText\n"
+                    )
                 }
             )
         },

--- a/feature/schedule/src/main/java/see/day/schedule/screen/ScheduleScreenRoot.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/screen/ScheduleScreenRoot.kt
@@ -54,6 +54,7 @@ import see.day.schedule.component.AlertTime
 import see.day.schedule.component.CalendarSetting
 import see.day.schedule.component.ColorPaletteBottomSheet
 import see.day.schedule.component.RepeatEndTime
+import see.day.schedule.component.RepeatSetting
 import see.day.schedule.component.RepeatTime
 import see.day.schedule.component.RepeatTimeBottomSheet
 import see.day.schedule.component.ScheduleTopBar
@@ -171,6 +172,7 @@ internal fun ScheduleDetailScreen(
                 onCheckedTimeChange = onCheckedTimeChange
             )
             RepeatSetting(
+                modifier = Modifier.padding(top = 16.dp),
                 startDate = startDate,
                 repeatTime = repeatTime,
                 repeatEndTime = repeatEndTime,
@@ -244,65 +246,6 @@ private fun ScheduleTitle(
                     innerTextField()
                 }
             }
-        )
-    }
-}
-
-@Composable
-private fun RepeatSetting(
-    modifier: Modifier = Modifier,
-    startDate: LocalDate,
-    repeatTime: RepeatTime,
-    repeatEndTime: RepeatEndTime?,
-    onCheckedChange: (RepeatTime, RepeatEndTime?) -> Unit,
-) {
-    var isShowRepeatBottomSheet by remember { mutableStateOf(false) }
-
-    if (isShowRepeatBottomSheet) {
-        RepeatTimeBottomSheet(
-            startDate = startDate,
-            repeatTime = repeatTime,
-            repeatEndTime = repeatEndTime,
-            onCheckedChange = onCheckedChange,
-            onDismiss = {
-                isShowRepeatBottomSheet = false
-            }
-        )
-    }
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 16.dp)
-            .clickable {
-                isShowRepeatBottomSheet = true
-            },
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Icon(
-            painter = painterResource(R.drawable.ic_repeat),
-            contentDescription = "반복 설정",
-            modifier = Modifier.size(24.dp),
-            tint = Color.Unspecified
-        )
-        Text(
-            modifier = Modifier.padding(start = 6.dp),
-            text = "반복",
-            style = MaterialTheme.typography.titleSmall
-        )
-        Spacer(modifier = Modifier.weight(1f))
-        Text(
-            text = stringResource(repeatTime.textRes) + if (repeatEndTime != null) ", ${repeatEndTime.dateStr} 종료" else "",
-            style = MaterialTheme.typography.labelSmall.copy(
-                color = gray70
-            )
-        )
-        Icon(
-            painter = painterResource(see.day.ui.R.drawable.ic_arrow_right),
-            contentDescription = "반복 설정",
-            modifier = Modifier
-                .size(20.dp)
-                .padding(start = 6.dp),
-            tint = Color.Unspecified
         )
     }
 }

--- a/feature/schedule/src/main/java/see/day/schedule/screen/ScheduleScreenRoot.kt
+++ b/feature/schedule/src/main/java/see/day/schedule/screen/ScheduleScreenRoot.kt
@@ -71,54 +71,16 @@ fun ScheduleDetailScreenRoot(onBack: () -> Unit, onClickPopHome: (Boolean) -> Un
     var startDate by remember { mutableStateOf(LocalDate.now()) }
     var endDate by remember { mutableStateOf(LocalDate.now()) }
 
-    var showAlertBottomSheet by remember { mutableStateOf(false) }
     var checkedTime by remember { mutableStateOf(AlertTime.NO) }
 
-    var showRepeatTimeBottomSheet by remember { mutableStateOf(false) }
     var checkedRepeatTime by remember { mutableStateOf(RepeatTime.NO) }
     var checkedRepeatEndTime by remember { mutableStateOf<RepeatEndTime?>(null) }
 
     var locationText by remember { mutableStateOf("") }
 
-    var showColorPaletteBottomSheet by remember { mutableStateOf(false) }
     var checkedColor by remember { mutableStateOf(primaryColor) }
 
     var memoText by remember { mutableStateOf("") }
-
-    if (showAlertBottomSheet) {
-        AlertBottomSheet(
-            onDismiss = {
-                showAlertBottomSheet = false
-            },
-            checkedTime = checkedTime,
-            onCheckedChange = { checkedTime = it }
-        )
-    }
-    if (showRepeatTimeBottomSheet) {
-        RepeatTimeBottomSheet(
-            repeatTime = checkedRepeatTime,
-            repeatEndTime = checkedRepeatEndTime,
-            startDate = LocalDate.now(),
-            onDismiss = {
-                showRepeatTimeBottomSheet = false
-            },
-            onCheckedChange = { repeatTime, repeatEndTime ->
-                checkedRepeatTime = repeatTime
-                checkedRepeatEndTime = repeatEndTime
-                showRepeatTimeBottomSheet = false
-            }
-        )
-    }
-
-    if (showColorPaletteBottomSheet) {
-        ColorPaletteBottomSheet(
-            selectedColor = checkedColor,
-            onDismiss = {
-                showColorPaletteBottomSheet = false
-            },
-            onColorSelected = { checkedColor = it }
-        )
-    }
 
     ScheduleDetailScreen(
         modifier = Modifier.systemBarsPadding(),


### PR DESCRIPTION
🔗 관련 이슈

📙 작업 설명
보기 좋게 패키지로 분리했다
작성하기 버튼 눌렀을때 적용한 값들을 볼 수 있게 로그로 찍었다.
🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 스케줄 설정 화면에 새로운 UI 컴포넌트 추가: 알림 시간, 일정 날짜, 색상, 위치, 메모, 반복 설정
  * 각 설정별 인터랙티브 하단 시트 및 입력 필드 추가
  * 메모 입력 시 최대 1000자 제한 및 문자 수 카운터 표시

* **Refactor**
  * 스케줄 화면의 상태 관리 구조 개선으로 더욱 모듈화된 설정 컴포넌트 구현

<!-- end of auto-generated comment: release notes by coderabbit.ai -->