### PR TITLE
[ANDROID-251] feat: 일정알림 on/off 설정

### DIFF
--- a/core/data/src/main/java/see/day/mapper/notification/NotificationMapper.kt
+++ b/core/data/src/main/java/see/day/mapper/notification/NotificationMapper.kt
@@ -38,7 +38,7 @@ fun NotificationSettingResponse.toModel(): NotificationSettings {
         exerciseRecordEnabled = exerciseNotificationEnabled,
         habitRecordEnabled = habitNotificationEnabled,
         goalSettingNotificationEnabled = goalSettingNotificationEnabled,
-//        scheduleNotificationEnabled = scheduleNotificationEnabled [TODO] 이름 변경될 수 있음
+        scheduleNotificationEnabled = scheduleNotificationEnabled
     )
 }
 
@@ -48,6 +48,6 @@ fun NotificationSettingsEdit.toDto(): NotificationSettingsEditRequest {
         exerciseNotificationEnabled = exerciseNotificationEnabled,
         habitNotificationEnabled = habitNotificationEnabled,
         goalSettingNotificationEnabled = goalSettingNotificationEnabled,
-//        scheduleNotificationEnabled = scheduleNotificationEnabled [TODO] 이름 변경될 수 있음
+        scheduleNotificationEnabled = scheduleNotificationEnabled
     )
 }

--- a/core/data/src/main/java/see/day/mapper/notification/NotificationMapper.kt
+++ b/core/data/src/main/java/see/day/mapper/notification/NotificationMapper.kt
@@ -37,15 +37,17 @@ fun NotificationSettingResponse.toModel(): NotificationSettings {
         dailyRecordEnabled = dailyRecordNotificationEnabled,
         exerciseRecordEnabled = exerciseNotificationEnabled,
         habitRecordEnabled = habitNotificationEnabled,
-        goalSettingNotificationEnabled = goalSettingNotificationEnabled
+        goalSettingNotificationEnabled = goalSettingNotificationEnabled,
+//        scheduleNotificationEnabled = scheduleNotificationEnabled [TODO] 이름 변경될 수 있음
     )
 }
 
-fun NotificationSettingsEdit.toDto() : NotificationSettingsEditRequest {
+fun NotificationSettingsEdit.toDto(): NotificationSettingsEditRequest {
     return NotificationSettingsEditRequest(
         dailyRecordNotificationEnabled = dailyRecordNotificationEnabled,
         exerciseNotificationEnabled = exerciseNotificationEnabled,
         habitNotificationEnabled = habitNotificationEnabled,
-        goalSettingNotificationEnabled = goalSettingNotificationEnabled
+        goalSettingNotificationEnabled = goalSettingNotificationEnabled,
+//        scheduleNotificationEnabled = scheduleNotificationEnabled [TODO] 이름 변경될 수 있음
     )
 }

--- a/core/data/src/main/java/see/day/network/dto/notification/NotificationSettingResponse.kt
+++ b/core/data/src/main/java/see/day/network/dto/notification/NotificationSettingResponse.kt
@@ -8,5 +8,6 @@ data class NotificationSettingResponse(
     val dailyRecordNotificationEnabled: Boolean,
     val exerciseNotificationEnabled: Boolean,
     val habitNotificationEnabled: Boolean,
-    val goalSettingNotificationEnabled: Boolean
+    val goalSettingNotificationEnabled: Boolean,
+//    val scheduleNotificationEnabled: Boolean [TODO] 이름 변경될 수 있음
 )

--- a/core/data/src/main/java/see/day/network/dto/notification/NotificationSettingResponse.kt
+++ b/core/data/src/main/java/see/day/network/dto/notification/NotificationSettingResponse.kt
@@ -9,5 +9,5 @@ data class NotificationSettingResponse(
     val exerciseNotificationEnabled: Boolean,
     val habitNotificationEnabled: Boolean,
     val goalSettingNotificationEnabled: Boolean,
-//    val scheduleNotificationEnabled: Boolean [TODO] 이름 변경될 수 있음
+    val scheduleNotificationEnabled: Boolean
 )

--- a/core/data/src/main/java/see/day/network/dto/notification/NotificationSettingsEditRequest.kt
+++ b/core/data/src/main/java/see/day/network/dto/notification/NotificationSettingsEditRequest.kt
@@ -8,5 +8,5 @@ data class NotificationSettingsEditRequest(
     val exerciseNotificationEnabled: Boolean?,
     val habitNotificationEnabled: Boolean?,
     val goalSettingNotificationEnabled: Boolean?,
-//    val scheduleNotificationEnabled: Boolean? // [TODO] 이름 변경될 수 있음
+    val scheduleNotificationEnabled: Boolean?
 )

--- a/core/data/src/main/java/see/day/network/dto/notification/NotificationSettingsEditRequest.kt
+++ b/core/data/src/main/java/see/day/network/dto/notification/NotificationSettingsEditRequest.kt
@@ -7,5 +7,6 @@ data class NotificationSettingsEditRequest(
     val dailyRecordNotificationEnabled : Boolean?,
     val exerciseNotificationEnabled: Boolean?,
     val habitNotificationEnabled: Boolean?,
-    val goalSettingNotificationEnabled: Boolean?
+    val goalSettingNotificationEnabled: Boolean?,
+//    val scheduleNotificationEnabled: Boolean? // [TODO] 이름 변경될 수 있음
 )

--- a/core/model/src/main/java/see/day/model/notification/NotificationSettings.kt
+++ b/core/model/src/main/java/see/day/model/notification/NotificationSettings.kt
@@ -6,5 +6,5 @@ data class NotificationSettings(
     val exerciseRecordEnabled: Boolean,
     val habitRecordEnabled: Boolean,
     val goalSettingNotificationEnabled: Boolean,
-//    val scheduleNotificationEnabled: Boolean // [TODO] 이름 변경될 수 있음
+    val scheduleNotificationEnabled: Boolean
 )

--- a/core/model/src/main/java/see/day/model/notification/NotificationSettings.kt
+++ b/core/model/src/main/java/see/day/model/notification/NotificationSettings.kt
@@ -5,5 +5,6 @@ data class NotificationSettings(
     val dailyRecordEnabled: Boolean,
     val exerciseRecordEnabled: Boolean,
     val habitRecordEnabled: Boolean,
-    val goalSettingNotificationEnabled: Boolean
+    val goalSettingNotificationEnabled: Boolean,
+//    val scheduleNotificationEnabled: Boolean // [TODO] 이름 변경될 수 있음
 )

--- a/core/model/src/main/java/see/day/model/notification/NotificationSettingsEdit.kt
+++ b/core/model/src/main/java/see/day/model/notification/NotificationSettingsEdit.kt
@@ -4,5 +4,6 @@ data class NotificationSettingsEdit(
     val dailyRecordNotificationEnabled : Boolean? = null,
     val exerciseNotificationEnabled: Boolean? = null,
     val habitNotificationEnabled: Boolean? = null,
-    val goalSettingNotificationEnabled: Boolean? = null
+    val goalSettingNotificationEnabled: Boolean? = null,
+    val scheduleNotificationEnabled: Boolean? = null
 )

--- a/feature/setting/src/main/java/see/day/setting/screen/SettingRecordNotificationScreenRoot.kt
+++ b/feature/setting/src/main/java/see/day/setting/screen/SettingRecordNotificationScreenRoot.kt
@@ -117,7 +117,8 @@ internal fun SettingRecordNotificationScreen(
                         RecordNotificationUiEvent.OnRecordNotificationChanged(
                             dailyRecordNotificationEnabled = currentChecked,
                             exerciseRecordNotificationEnabled = currentChecked,
-                            habitRecordNotificationEnabled = currentChecked
+                            habitRecordNotificationEnabled = currentChecked,
+                            scheduleNotificationEnabled = currentChecked,
                         )
                     )
                 }

--- a/feature/setting/src/main/java/see/day/setting/screen/SettingRecordNotificationScreenRoot.kt
+++ b/feature/setting/src/main/java/see/day/setting/screen/SettingRecordNotificationScreenRoot.kt
@@ -175,6 +175,21 @@ internal fun SettingRecordNotificationScreen(
                     )
                 }
             )
+
+            NotificationSwitch(
+                modifier = Modifier.padding(top = 24.dp),
+                title = R.string.schedule_notification,
+                body = R.string.habit_time_notification,
+                checked = uiState.scheduleNotificationEnabled,
+                isAllChecked = uiState.isAllNotificationEnabled(),
+                onCheckedChanged = { currentChecked ->
+                    onAction(
+                        RecordNotificationUiEvent.OnRecordNotificationChanged(
+                            scheduleNotificationEnabled = currentChecked,
+                        )
+                    )
+                }
+            )
         }
     }
 }

--- a/feature/setting/src/main/java/see/day/setting/state/record/RecordNotificationUiEvent.kt
+++ b/feature/setting/src/main/java/see/day/setting/state/record/RecordNotificationUiEvent.kt
@@ -5,6 +5,7 @@ sealed interface RecordNotificationUiEvent {
     data class OnRecordNotificationChanged(
         val dailyRecordNotificationEnabled: Boolean? = null,
         val exerciseRecordNotificationEnabled: Boolean? = null,
-        val habitRecordNotificationEnabled: Boolean? = null
+        val habitRecordNotificationEnabled: Boolean? = null,
+        val scheduleNotificationEnabled: Boolean? = null
     ) : RecordNotificationUiEvent
 }

--- a/feature/setting/src/main/java/see/day/setting/state/record/RecordNotificationUiState.kt
+++ b/feature/setting/src/main/java/see/day/setting/state/record/RecordNotificationUiState.kt
@@ -3,11 +3,12 @@ package see.day.setting.state.record
 data class RecordNotificationUiState(
     val dailyRecordNotificationEnabled: Boolean,
     val exerciseRecordNotificationEnabled: Boolean,
-    val habitRecordNotificationEnabled: Boolean
+    val habitRecordNotificationEnabled: Boolean,
+    val scheduleNotificationEnabled: Boolean // [TODO] 이름 변경될 수 있음
 ) {
-    fun isAllNotificationEnabled() = dailyRecordNotificationEnabled && exerciseRecordNotificationEnabled && habitRecordNotificationEnabled
+    fun isAllNotificationEnabled() = dailyRecordNotificationEnabled && exerciseRecordNotificationEnabled && habitRecordNotificationEnabled && scheduleNotificationEnabled
 
     companion object {
-        val init = RecordNotificationUiState(false, false, false)
+        val init = RecordNotificationUiState(false, false, false, false)
     }
 }

--- a/feature/setting/src/main/java/see/day/setting/viewModel/RecordNotificationViewModel.kt
+++ b/feature/setting/src/main/java/see/day/setting/viewModel/RecordNotificationViewModel.kt
@@ -37,7 +37,8 @@ class RecordNotificationViewModel @Inject constructor(
                         it.copy(
                             dailyRecordNotificationEnabled = notificationSetting.dailyRecordEnabled,
                             exerciseRecordNotificationEnabled = notificationSetting.exerciseRecordEnabled,
-                            habitRecordNotificationEnabled = notificationSetting.habitRecordEnabled
+                            habitRecordNotificationEnabled = notificationSetting.habitRecordEnabled,
+//                            scheduleNotificationEnabled = notificationSetting.scheduleNotificationEnabled
                         )
                     }
                 }
@@ -54,7 +55,8 @@ class RecordNotificationViewModel @Inject constructor(
                 onChangedRecordNotification(
                     dailyRecordEnabled = uiEvent.dailyRecordNotificationEnabled,
                     exerciseRecordEnabled = uiEvent.exerciseRecordNotificationEnabled,
-                    habitRecordEnabled = uiEvent.habitRecordNotificationEnabled
+                    habitRecordEnabled = uiEvent.habitRecordNotificationEnabled,
+                    scheduleNotificationEnabled = uiEvent.scheduleNotificationEnabled
                 )
             }
         }
@@ -69,21 +71,24 @@ class RecordNotificationViewModel @Inject constructor(
     private fun onChangedRecordNotification(
         dailyRecordEnabled: Boolean?,
         exerciseRecordEnabled: Boolean?,
-        habitRecordEnabled: Boolean?
+        habitRecordEnabled: Boolean?,
+        scheduleNotificationEnabled: Boolean?
     ) {
         viewModelScope.launch {
             notificationRepository.updateNotificationSetting(
                 NotificationSettingsEdit(
                     dailyRecordNotificationEnabled = dailyRecordEnabled,
                     exerciseNotificationEnabled = exerciseRecordEnabled,
-                    habitNotificationEnabled = habitRecordEnabled
+                    habitNotificationEnabled = habitRecordEnabled,
+//                    scheduleNotificationEnabled = scheduleNotificationEnabled
                 )
             ).onSuccess { notificationSetting ->
                 _uiState.update {
                     it.copy(
                         dailyRecordNotificationEnabled = notificationSetting.dailyRecordEnabled,
                         exerciseRecordNotificationEnabled = notificationSetting.exerciseRecordEnabled,
-                        habitRecordNotificationEnabled = notificationSetting.habitRecordEnabled
+                        habitRecordNotificationEnabled = notificationSetting.habitRecordEnabled,
+//                        scheduleNotificationEnabled = notificationSetting.scheduleNotificationEnabled
                     )
                 }
             }

--- a/feature/setting/src/main/java/see/day/setting/viewModel/RecordNotificationViewModel.kt
+++ b/feature/setting/src/main/java/see/day/setting/viewModel/RecordNotificationViewModel.kt
@@ -38,7 +38,7 @@ class RecordNotificationViewModel @Inject constructor(
                             dailyRecordNotificationEnabled = notificationSetting.dailyRecordEnabled,
                             exerciseRecordNotificationEnabled = notificationSetting.exerciseRecordEnabled,
                             habitRecordNotificationEnabled = notificationSetting.habitRecordEnabled,
-//                            scheduleNotificationEnabled = notificationSetting.scheduleNotificationEnabled
+                            scheduleNotificationEnabled = notificationSetting.scheduleNotificationEnabled
                         )
                     }
                 }
@@ -80,7 +80,7 @@ class RecordNotificationViewModel @Inject constructor(
                     dailyRecordNotificationEnabled = dailyRecordEnabled,
                     exerciseNotificationEnabled = exerciseRecordEnabled,
                     habitNotificationEnabled = habitRecordEnabled,
-//                    scheduleNotificationEnabled = scheduleNotificationEnabled
+                    scheduleNotificationEnabled = scheduleNotificationEnabled
                 )
             ).onSuccess { notificationSetting ->
                 _uiState.update {
@@ -88,7 +88,7 @@ class RecordNotificationViewModel @Inject constructor(
                         dailyRecordNotificationEnabled = notificationSetting.dailyRecordEnabled,
                         exerciseRecordNotificationEnabled = notificationSetting.exerciseRecordEnabled,
                         habitRecordNotificationEnabled = notificationSetting.habitRecordEnabled,
-//                        scheduleNotificationEnabled = notificationSetting.scheduleNotificationEnabled
+                        scheduleNotificationEnabled = notificationSetting.scheduleNotificationEnabled
                     )
                 }
             }

--- a/feature/setting/src/main/res/values/strings.xml
+++ b/feature/setting/src/main/res/values/strings.xml
@@ -26,6 +26,7 @@
     <string name="record_notification">미 기록 알림</string>
     <string name="exercise_record_notification">운동 기록</string>
     <string name="habit_record_notification">습관 기록</string>
+    <string name="schedule_notification">일정 알림</string>
     <string name="habit_time_notification">등록 시간 알림</string>
 
     <string name="system_notification_banner_title">현재 시스템 알림이 꺼져있어요.\n지금 바로 알림을 켜주세요!</string>


### PR DESCRIPTION
🔗 관련 이슈

📙 작업 설명

🧪 테스트 내역 (선택)

📸 스크린샷 또는 시연 영상 (선택)

💬 추가 설명 or 리뷰 포인트 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 알림 설정에 일정 알림 옵션 추가 - 사용자가 일정 관련 알림을 독립적으로 활성화하거나 비활성화할 수 있습니다.
* 전체 알림 토글 기능 개선 - 일일 기록, 운동 기록, 습관, 일정 4가지 모든 알림을 한 번에 제어할 수 있도록 개선되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Record-Management/Android/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->